### PR TITLE
fix: 실제 응답과 swagger 문서 간 status code 불일치 해결

### DIFF
--- a/src/main/java/com/ktb3/devths/auth/controller/AuthController.java
+++ b/src/main/java/com/ktb3/devths/auth/controller/AuthController.java
@@ -66,6 +66,7 @@ public class AuthController {
 	/**
 	 * 로그아웃
 	 */
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204")
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponse<Void>> logout(
 		@AuthenticationPrincipal UserPrincipal userPrincipal,

--- a/src/main/java/com/ktb3/devths/global/storage/controller/FileController.java
+++ b/src/main/java/com/ktb3/devths/global/storage/controller/FileController.java
@@ -40,6 +40,7 @@ public class FileController {
 			.body(ApiResponse.success("Presigned URL이 생성되었습니다.", response));
 	}
 
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201")
 	@PostMapping
 	public ResponseEntity<ApiResponse<FileAttachmentResponse>> saveAttachment(
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -54,6 +55,7 @@ public class FileController {
 			.body(ApiResponse.success("파일 정보가 성공적으로 등록되었습니다.", response));
 	}
 
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204")
 	@DeleteMapping("/{fileId}")
 	public ResponseEntity<Void> deleteAttachment(
 		@AuthenticationPrincipal UserPrincipal userPrincipal,

--- a/src/main/java/com/ktb3/devths/user/controller/UserController.java
+++ b/src/main/java/com/ktb3/devths/user/controller/UserController.java
@@ -32,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 	private final UserService userService;
 
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201")
 	@PostMapping
 	public ResponseEntity<ApiResponse<UserSignupResponse>> signup(
 		@Valid @RequestBody UserSignupRequest request,
@@ -69,6 +70,7 @@ public class UserController {
 		);
 	}
 
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204")
 	@DeleteMapping
 	public ResponseEntity<Void> withdraw(
 		@AuthenticationPrincipal UserPrincipal userPrincipal


### PR DESCRIPTION
## 📌 작업한 내용
- 성공 응답이 200이 아닌 엔드포인트들에 대해 `@ApiResponse(responseCode="")` 어노테이션 추가

## 🔍 참고 사항
- 임시 설정이므로 추후 리팩토링 필요
 
## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

#22 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인