### PR TITLE
feat: health check API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/ktb3/devths/global/config/SecurityConfig.java
+++ b/src/main/java/com/ktb3/devths/global/config/SecurityConfig.java
@@ -32,8 +32,9 @@ public class SecurityConfig {
 			.cors(cors -> cors.configurationSource(corsConfigurationSource))
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/api/auth/google", "/api/auth/tokens", "/api/users", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
-				.requestMatchers("/api/admin/**").hasRole("ADMIN")
+				.requestMatchers("/api/auth/google", "/api/auth/tokens", "/api/users", "/v3/api-docs/**", "/swagger-ui/**",
+					"/actuator/health", "/actuator/info").permitAll()
+				.requestMatchers("/api/admin/**", "/actuator/**").hasRole("ADMIN")
 				.anyRequest().authenticated()
 			)
 			.exceptionHandling(exceptions -> exceptions

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,3 +60,12 @@ cloud:
       bucket: ${S3_BUCKET}
     stack:
       auto: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: never


### PR DESCRIPTION
## 📌 작업한 내용
- Spring Actuator 기반 health check 엔드포인트 추가

## 🔍 참고 사항
- health, info만 노출
  - `/actuator/health`, `/actuator/info`로 접근 가능
- info는 현재 빈 값

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

#24 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인