### PR TITLE
fix: 챗봇 메시지 불러오기 시 정렬 순서 변경

### DIFF
--- a/src/main/java/com/ktb3/devths/chatbot/repository/AiChatMessageRepository.java
+++ b/src/main/java/com/ktb3/devths/chatbot/repository/AiChatMessageRepository.java
@@ -11,14 +11,14 @@ import com.ktb3.devths.chatbot.domain.entity.AiChatMessage;
 
 public interface AiChatMessageRepository extends JpaRepository<AiChatMessage, Long> {
 
-	@Query("SELECT m FROM AiChatMessage m " + "WHERE m.room.id = :roomId " + "ORDER BY m.createdAt DESC, m.id DESC")
-	List<AiChatMessage> findByRoomIdOrderByCreatedAtDesc(
+	@Query("SELECT m FROM AiChatMessage m " + "WHERE m.room.id = :roomId " + "ORDER BY m.createdAt ASC, m.id ASC")
+	List<AiChatMessage> findByRoomIdOrderByCreatedAtAsc(
 		@Param("roomId") Long roomId,
 		Pageable pageable
 	);
 
-	@Query("SELECT m FROM AiChatMessage m " + "WHERE m.room.id = :roomId " + "AND m.id < :lastId " + "ORDER BY m.createdAt DESC, m.id DESC")
-	List<AiChatMessage> findByRoomIdAndIdLessThanOrderByCreatedAtDesc(
+	@Query("SELECT m FROM AiChatMessage m " + "WHERE m.room.id = :roomId " + "AND m.id > :lastId " + "ORDER BY m.createdAt ASC, m.id ASC")
+	List<AiChatMessage> findByRoomIdAndIdLessThanOrderByCreatedAtAsc(
 		@Param("roomId") Long roomId,
 		@Param("lastId") Long lastId,
 		Pageable pageable

--- a/src/main/java/com/ktb3/devths/chatbot/service/AiChatRoomService.java
+++ b/src/main/java/com/ktb3/devths/chatbot/service/AiChatRoomService.java
@@ -76,8 +76,8 @@ public class AiChatRoomService {
 		Pageable pageable = PageRequest.of(0, pageSize + 1);
 
 		List<AiChatMessage> messages = (lastId == null)
-			? aiChatMessageRepository.findByRoomIdOrderByCreatedAtDesc(roomId, pageable)
-			: aiChatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(roomId, lastId, pageable);
+			? aiChatMessageRepository.findByRoomIdOrderByCreatedAtAsc(roomId, pageable)
+			: aiChatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtAsc(roomId, lastId, pageable);
 
 		return AiChatMessageListResponse.of(messages, pageSize);
 	}


### PR DESCRIPTION
## 📌 작업한 내용
- 챗봇 메시지 조회 쿼리의 정렬 로직 변경
  - 기존: created_at DESC, id DESC (최신순)
  - 변경: created_at ASC, id ASC (오래된순)

## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#31 

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인