### PR TITLE
[#33] chore: Main 관련 브랜치 병합 룰 정의 

### DIFF
--- a/.github/workflows/devths-pr.yml
+++ b/.github/workflows/devths-pr.yml
@@ -217,7 +217,7 @@ jobs:
             - Lint: ${{ steps.prep.outputs.branch_guard_allowed == 'true' && (needs.lint.result == 'success' && '✅' || '❌') || ' ⚪️ (브랜치 가드 차단)' }}
             - Static Analysis: ${{ steps.prep.outputs.branch_guard_allowed == 'true' && (needs.static_analysis.result == 'success' && '✅' || '❌') || ' ⚪️ (브랜치 가드 차단)' }}
 
-            ${{ needs.static_analysis.result != 'success' && '⚠️ **정적 분석 실패로 인해 파이프라인이 중단되었습니다.**' || '' }}
+            ${{ steps.prep.outputs.branch_guard_allowed == 'true' && needs.static_analysis.result == 'failure' && '⚠️ **정적 분석 실패로 인해 파이프라인이 중단되었습니다.**' || '' }}
 
             **🔗 링크**: [PR 확인하기](${{ github.event.pull_request.html_url }})
           color: "${{ steps.prep.outputs.branch_guard_allowed == 'true' && needs.lint.result == 'success' && needs.static_analysis.result == 'success' && 65280 || 16711680 }}"


### PR DESCRIPTION
## 📌 작업한 내용
Main 브랜치에 release 브랜치와 hotfix 브랜치만 병합되도록 GitHub 브랜치 보호 룰을 설정했습니다. 이를 통해 main 브랜치의 안정성을 유지하고 feature/develop 등의 직접 병합을 방지하여 Git Flow와 유사한 워크플로를 적용했습니다. )

## 🔍 참고 사항
GitHub 리포지토리 Settings > Branches에서 main 브랜치 보호 규칙을 추가하여 설정을 완료했습니다. 

## 🖼️ 스크린샷
설정 변경 사항으로 스크린샷 없음.

## 🔗 관련 이슈
#33 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인