### PR TITLE
bug: 구글 로그인 시 403 Forbidden 오류 발생

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,10 +44,14 @@ encryption:
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS}
   allowed-methods: GET,POST,PUT,DELETE,PATCH,OPTIONS
-  allowed-headers: "*"
+  allowed-headers: Content-Type,Authorization,Accept,X-Requested-With
   exposed-headers: Authorization
   allow-credentials: true
   max-age: 3600
+
+server:
+  # Nginx가 보내준 X-Forwarded-* 헤더를 사용하여 클라이언트 정보를 덮어씌움
+  forward-headers-strategy: native
 
 cloud:
   aws:


### PR DESCRIPTION
## 📌 작업한 내용
- CORS 관련 설정 중 allowed-headers가 와일드카드(`"*"`)로 설정되어 있던 것을 명시적으로 변경

## 🔍 참고 사항
- Preflight 요청 403 이슈는 Nginx에서 바로 받아치는 구조로 변경하여 해결

## 🖼️ 스크린샷

## 🔗 관련 이슈

#51 

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인