### PR TITLE
fix: RT 중복 저장으로 setDomain 제거

### DIFF
--- a/src/main/java/com/ktb3/devths/auth/util/CookieUtil.java
+++ b/src/main/java/com/ktb3/devths/auth/util/CookieUtil.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.Cookie;
 public class CookieUtil {
 	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 	private static final String COOKIE_PATH = "/api/auth";
-	private static final String COOKIE_DOMAIN = "devths.com";
 	private static final int REFRESH_TOKEN_MAX_AGE = 14 * 24 * 60 * 60; // 14일 (초 단위)
 
 	/**
@@ -18,7 +17,6 @@ public class CookieUtil {
 		Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
 		cookie.setHttpOnly(true);
 		cookie.setSecure(true);
-		cookie.setDomain(COOKIE_DOMAIN);
 		cookie.setPath(COOKIE_PATH);
 		cookie.setMaxAge(REFRESH_TOKEN_MAX_AGE);
 		cookie.setAttribute("SameSite", "Lax");
@@ -35,7 +33,6 @@ public class CookieUtil {
 		Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, "");
 		cookie.setHttpOnly(true);
 		cookie.setSecure(true);
-		cookie.setDomain(COOKIE_DOMAIN);
 		cookie.setPath(COOKIE_PATH);
 		cookie.setMaxAge(0);
 		cookie.setAttribute("SameSite", "Lax");


### PR DESCRIPTION
## 📌 작업한 내용
- setDomain으로 인한 RT 쿠키 중복 저장으로 401 발생
- 
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#62 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인