### PR TITLE
fix: jobPost DTO 필드명 매칭 문제 해결 (#68)

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/analysis/dto/request/DocumentAnalysisRequest.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/dto/request/DocumentAnalysisRequest.java
@@ -12,7 +12,7 @@ public record DocumentAnalysisRequest(
 	DocumentInfo resume,
 
 	@NotNull(message = "채용공고 정보는 필수입니다")
-	DocumentInfo jobPosting
+	DocumentInfo jobPost
 ) {
 	public record DocumentInfo(
 		Long fileId,

--- a/src/main/java/com/ktb3/devths/ai/analysis/service/AsyncAnalysisProcessor.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/service/AsyncAnalysisProcessor.java
@@ -79,7 +79,7 @@ public class AsyncAnalysisProcessor {
 		DocumentAnalysisRequest request) {
 
 		FastApiAnalysisRequest.FastApiDocumentInfo resumeInfo = buildDocumentInfo(request.resume(), userId);
-		FastApiAnalysisRequest.FastApiDocumentInfo jobPostingInfo = buildDocumentInfo(request.jobPosting(),
+		FastApiAnalysisRequest.FastApiDocumentInfo jobPostingInfo = buildDocumentInfo(request.jobPost(),
 			userId);
 
 		return new FastApiAnalysisRequest(

--- a/src/main/java/com/ktb3/devths/ai/analysis/service/DocumentAnalysisService.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/service/DocumentAnalysisService.java
@@ -48,7 +48,7 @@ public class DocumentAnalysisService {
 		}
 
 		validateDocumentInfo(request.resume());
-		validateDocumentInfo(request.jobPosting());
+		validateDocumentInfo(request.jobPost());
 
 		List<AsyncTask> existingTasks = asyncTaskRepository.findByReferenceIdAndTaskTypeAndStatusIn(
 			roomId,


### PR DESCRIPTION
## 📌 작업한 내용
- `DocumentAnalysisRequest.java`에서 jobPosting 필드명을 jobPost로 변경
- 해당 DTO를 사용하던 `DocumentAnalysisService.java`와 `AsyncAnalysisProcessor.java`의 필드명도 적절하게 변경
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#68 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인