### PR TITLE
fix: '비동기 작업을 찾을 수 없습니다' 문제 해결을 위해 DB 커밋 전에 task를 조회하던 로직 수정

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/analysis/controller/DocumentAnalysisController.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/controller/DocumentAnalysisController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ktb3.devths.ai.analysis.dto.request.DocumentAnalysisRequest;
 import com.ktb3.devths.ai.analysis.dto.response.DocumentAnalysisResponse;
-import com.ktb3.devths.ai.analysis.service.DocumentAnalysisService;
+import com.ktb3.devths.ai.analysis.service.DocumentAnalysisFacade;
 import com.ktb3.devths.global.response.ApiResponse;
 import com.ktb3.devths.global.security.UserPrincipal;
 
@@ -25,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class DocumentAnalysisController {
 
-	private final DocumentAnalysisService documentAnalysisService;
+	private final DocumentAnalysisFacade documentAnalysisFacade;
 
 	@PostMapping("/chatrooms/{roomId}/analysis")
 	public ResponseEntity<ApiResponse<DocumentAnalysisResponse>> startAnalysis(
@@ -36,7 +36,7 @@ public class DocumentAnalysisController {
 		long startTime = System.currentTimeMillis();
 		Long userId = userPrincipal.getUserId();
 
-		DocumentAnalysisResponse response = documentAnalysisService.startAnalysis(userId, roomId, request);
+		DocumentAnalysisResponse response = documentAnalysisFacade.startAnalysis(userId, roomId, request);
 
 		long duration = System.currentTimeMillis() - startTime;
 		log.info("분석 요청 응답 시간: {}ms (비동기 동작 확인: {}ms 미만이어야 정상)", duration, 1000);

--- a/src/main/java/com/ktb3/devths/ai/analysis/service/DocumentAnalysisFacade.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/service/DocumentAnalysisFacade.java
@@ -1,0 +1,22 @@
+package com.ktb3.devths.ai.analysis.service;
+
+import org.springframework.stereotype.Service;
+
+import com.ktb3.devths.ai.analysis.dto.request.DocumentAnalysisRequest;
+import com.ktb3.devths.ai.analysis.dto.response.DocumentAnalysisResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DocumentAnalysisFacade {
+
+	private final DocumentAnalysisService documentAnalysisService;
+	private final AsyncAnalysisProcessor asyncAnalysisProcessor;
+
+	public DocumentAnalysisResponse startAnalysis(Long userId, Long roomId, DocumentAnalysisRequest request) {
+		DocumentAnalysisResponse response = documentAnalysisService.startAnalysis(userId, roomId, request);
+		asyncAnalysisProcessor.processAnalysis(response.taskId(), userId, roomId, request);
+		return response;
+	}
+}

--- a/src/main/java/com/ktb3/devths/ai/analysis/service/DocumentAnalysisService.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/service/DocumentAnalysisService.java
@@ -31,7 +31,6 @@ public class DocumentAnalysisService {
 	private final AiChatRoomRepository aiChatRoomRepository;
 	private final AsyncTaskRepository asyncTaskRepository;
 	private final AsyncTaskService asyncTaskService;
-	private final AsyncAnalysisProcessor asyncAnalysisProcessor;
 
 	@Transactional
 	public DocumentAnalysisResponse startAnalysis(Long userId, Long roomId,
@@ -66,8 +65,6 @@ public class DocumentAnalysisService {
 		}
 
 		AsyncTask task = asyncTaskService.createTask(user, TaskType.ANALYSIS, roomId);
-
-		asyncAnalysisProcessor.processAnalysis(task.getId(), userId, roomId, request);
 
 		return new DocumentAnalysisResponse(task.getId(), TaskStatus.PENDING.name());
 	}


### PR DESCRIPTION
## 📌 작업한 내용
- 비동기 작업 Task가 생성된 뒤 DB에 커밋되기 전 해당 Task를 조회하던 문제 해결
  - `DocumentAnalysisFacade.java` 추가
  - 트랜잭션 커밋 이후 비동기 실행을 보장하기 위한 호출 순서 조정
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#70 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인