### PR TITLE
fix: 이력서 분석 엔드포인트 URI 매핑 실패 해결 (#70)

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/analysis/controller/DocumentAnalysisController.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/controller/DocumentAnalysisController.java
@@ -21,13 +21,13 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/ai")
+@RequestMapping("/api/ai-chatrooms")
 @RequiredArgsConstructor
 public class DocumentAnalysisController {
 
 	private final DocumentAnalysisFacade documentAnalysisFacade;
 
-	@PostMapping("/chatrooms/{roomId}/analysis")
+	@PostMapping("/{roomId}/analysis")
 	public ResponseEntity<ApiResponse<DocumentAnalysisResponse>> startAnalysis(
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@PathVariable Long roomId,


### PR DESCRIPTION
## 📌 작업한 내용
- 분석 엔드포인트 URI가 잘못 설정되어 있는 부분 해결

## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#70 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인