### PR TITLE
feat: 면접 모드 시작/종료 구현 (#66)

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/chatbot/domain/entity/AiChatInterview.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/domain/entity/AiChatInterview.java
@@ -62,4 +62,11 @@ public class AiChatInterview {
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
 
+	public void incrementQuestionCount() {
+		this.currentQuestionCount++;
+	}
+
+	public void complete() {
+		this.status = InterviewStatus.COMPLETED;
+	}
 }

--- a/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/AiChatMessageRequest.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/AiChatMessageRequest.java
@@ -10,6 +10,8 @@ public record AiChatMessageRequest(
 	String content,
 
 	@NotNull(message = "AI 모델은 필수입니다")
-	AiModel model
+	AiModel model,
+
+	Long interviewId
 ) {
 }

--- a/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/FastApiInterviewEvaluationRequest.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/FastApiInterviewEvaluationRequest.java
@@ -1,0 +1,21 @@
+package com.ktb3.devths.ai.chatbot.dto.request;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record FastApiInterviewEvaluationRequest(
+	@JsonProperty("interview_id")
+	Long interviewId,
+
+	@JsonProperty("interview_type")
+	String interviewType,
+
+	List<FastApiInterviewMessage> messages
+) {
+	public record FastApiInterviewMessage(
+		String role,
+		String content
+	) {
+	}
+}

--- a/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/InterviewEvaluationRequest.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/InterviewEvaluationRequest.java
@@ -1,0 +1,9 @@
+package com.ktb3.devths.ai.chatbot.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record InterviewEvaluationRequest(
+	@NotNull(message = "면접 ID는 필수입니다")
+	Long interviewId
+) {
+}

--- a/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/InterviewStartRequest.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/InterviewStartRequest.java
@@ -1,0 +1,15 @@
+package com.ktb3.devths.ai.chatbot.dto.request;
+
+import com.ktb3.devths.ai.chatbot.domain.constant.InterviewType;
+import com.ktb3.devths.ai.constant.AiModel;
+
+import jakarta.validation.constraints.NotNull;
+
+public record InterviewStartRequest(
+	@NotNull(message = "면접 유형은 필수입니다")
+	InterviewType interviewType,
+
+	@NotNull(message = "AI 모델은 필수입니다")
+	AiModel model
+) {
+}

--- a/src/main/java/com/ktb3/devths/ai/chatbot/dto/response/InterviewStartResponse.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/dto/response/InterviewStartResponse.java
@@ -1,0 +1,7 @@
+package com.ktb3.devths.ai.chatbot.dto.response;
+
+public record InterviewStartResponse(
+	Long interviewId,
+	String interviewType
+) {
+}

--- a/src/main/java/com/ktb3/devths/ai/chatbot/repository/AiChatInterviewRepository.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/repository/AiChatInterviewRepository.java
@@ -1,0 +1,12 @@
+package com.ktb3.devths.ai.chatbot.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ktb3.devths.ai.chatbot.domain.constant.InterviewStatus;
+import com.ktb3.devths.ai.chatbot.domain.entity.AiChatInterview;
+
+public interface AiChatInterviewRepository extends JpaRepository<AiChatInterview, Long> {
+	Optional<AiChatInterview> findByRoomIdAndStatus(Long roomId, InterviewStatus status);
+}

--- a/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatInterviewService.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatInterviewService.java
@@ -1,0 +1,103 @@
+package com.ktb3.devths.ai.chatbot.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ktb3.devths.ai.analysis.repository.AiOcrResultRepository;
+import com.ktb3.devths.ai.chatbot.domain.constant.InterviewStatus;
+import com.ktb3.devths.ai.chatbot.domain.constant.InterviewType;
+import com.ktb3.devths.ai.chatbot.domain.entity.AiChatInterview;
+import com.ktb3.devths.ai.chatbot.domain.entity.AiChatMessage;
+import com.ktb3.devths.ai.chatbot.domain.entity.AiChatRoom;
+import com.ktb3.devths.ai.chatbot.dto.request.FastApiInterviewEvaluationRequest;
+import com.ktb3.devths.ai.chatbot.repository.AiChatInterviewRepository;
+import com.ktb3.devths.ai.chatbot.repository.AiChatMessageRepository;
+import com.ktb3.devths.ai.client.FastApiClient;
+import com.ktb3.devths.global.exception.CustomException;
+import com.ktb3.devths.global.response.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiChatInterviewService {
+
+	private final AiChatInterviewRepository aiChatInterviewRepository;
+	private final AiChatMessageRepository aiChatMessageRepository;
+	private final AiOcrResultRepository aiOcrResultRepository;
+	private final FastApiClient fastApiClient;
+
+	@Transactional
+	public AiChatInterview startInterview(AiChatRoom room, InterviewType interviewType) {
+		aiChatInterviewRepository.findByRoomIdAndStatus(room.getId(), InterviewStatus.IN_PROGRESS)
+			.ifPresent(interview -> {
+				throw new CustomException(ErrorCode.INTERVIEW_ALREADY_IN_PROGRESS);
+			});
+
+		AiChatInterview interview = AiChatInterview.builder()
+			.room(room)
+			.interviewType(interviewType)
+			.currentQuestionCount(0)
+			.status(InterviewStatus.IN_PROGRESS)
+			.build();
+
+		AiChatInterview savedInterview = aiChatInterviewRepository.save(interview);
+		log.info("면접 시작: interviewId={}, roomId={}, type={}", savedInterview.getId(), room.getId(), interviewType);
+
+		return savedInterview;
+	}
+
+	@Transactional
+	public void completeInterview(Long interviewId) {
+		AiChatInterview interview = aiChatInterviewRepository.findById(interviewId)
+			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
+
+		interview.complete();
+		log.info("면접 완료: interviewId={}", interviewId);
+	}
+
+	@Transactional(readOnly = true)
+	public AiChatInterview getInterview(Long interviewId) {
+		return aiChatInterviewRepository.findById(interviewId)
+			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
+	}
+
+	public Flux<String> evaluateInterview(Long interviewId) {
+		AiChatInterview interview = getInterview(interviewId);
+
+		List<AiChatMessage> messages = aiChatMessageRepository.findAll().stream()
+			.filter(msg -> msg.getInterview() != null && msg.getInterview().getId().equals(interviewId))
+			.collect(Collectors.toList());
+
+		if (messages.isEmpty()) {
+			throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+		}
+
+		List<FastApiInterviewEvaluationRequest.FastApiInterviewMessage> interviewMessages = messages.stream()
+			.map(msg -> new FastApiInterviewEvaluationRequest.FastApiInterviewMessage(
+				msg.getRole().name().toLowerCase(),
+				msg.getContent()
+			))
+			.collect(Collectors.toList());
+
+		FastApiInterviewEvaluationRequest request = new FastApiInterviewEvaluationRequest(
+			interviewId,
+			interview.getInterviewType().name().toLowerCase(),
+			interviewMessages
+		);
+
+		log.info("면접 평가 시작: interviewId={}, messageCount={}", interviewId, messages.size());
+
+		return fastApiClient.streamInterviewEvaluation(request)
+			.doOnComplete(() -> {
+				completeInterview(interviewId);
+				log.info("면접 평가 완료: interviewId={}", interviewId);
+			});
+	}
+}

--- a/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatMessageService.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatMessageService.java
@@ -7,12 +7,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ktb3.devths.ai.analysis.domain.AiOcrResult;
+import com.ktb3.devths.ai.analysis.repository.AiOcrResultRepository;
 import com.ktb3.devths.ai.chatbot.domain.constant.MessageRole;
 import com.ktb3.devths.ai.chatbot.domain.constant.MessageType;
+import com.ktb3.devths.ai.chatbot.domain.entity.AiChatInterview;
 import com.ktb3.devths.ai.chatbot.domain.entity.AiChatMessage;
 import com.ktb3.devths.ai.chatbot.domain.entity.AiChatRoom;
 import com.ktb3.devths.ai.chatbot.dto.request.FastApiChatContext;
 import com.ktb3.devths.ai.chatbot.dto.request.FastApiChatRequest;
+import com.ktb3.devths.ai.chatbot.repository.AiChatInterviewRepository;
 import com.ktb3.devths.ai.chatbot.repository.AiChatMessageRepository;
 import com.ktb3.devths.ai.chatbot.repository.AiChatRoomRepository;
 import com.ktb3.devths.ai.client.FastApiClient;
@@ -32,6 +36,8 @@ public class AiChatMessageService {
 
 	private final AiChatMessageRepository aiChatMessageRepository;
 	private final AiChatRoomRepository aiChatRoomRepository;
+	private final AiChatInterviewRepository aiChatInterviewRepository;
+	private final AiOcrResultRepository aiOcrResultRepository;
 	private final FastApiClient fastApiClient;
 
 	@Transactional
@@ -50,11 +56,13 @@ public class AiChatMessageService {
 		return aiChatMessageRepository.save(message);
 	}
 
-	public Flux<String> streamChatResponse(Long userId, Long roomId, String content, AiModel model) {
-		log.info("AI 챗봇 스트리밍 시작: roomId={}, userId={}, model={}",
+	public Flux<String> streamChatResponse(Long userId, Long roomId, String content, AiModel model,
+		Long interviewId) {
+		log.info("AI 챗봇 스트리밍 시작: roomId={}, userId={}, model={}, interviewId={}",
 			LogSanitizer.sanitize(String.valueOf(roomId)),
 			LogSanitizer.sanitize(String.valueOf(userId)),
-			model);
+			model,
+			interviewId);
 
 		AiChatRoom room = aiChatRoomRepository.findByIdAndIsDeletedFalse(roomId)
 			.orElseThrow(() -> new CustomException(ErrorCode.AI_CHATROOM_NOT_FOUND));
@@ -63,15 +71,40 @@ public class AiChatMessageService {
 			throw new CustomException(ErrorCode.AI_CHATROOM_ACCESS_DENIED);
 		}
 
-		saveUserMessage(room, content);
+		AiChatInterview interview = null;
+		FastApiChatContext context = FastApiChatContext.createNormalMode();
+
+		if (interviewId != null) {
+			interview = aiChatInterviewRepository.findById(interviewId)
+				.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
+
+			interview.incrementQuestionCount();
+
+			AiOcrResult ocrResult = aiOcrResultRepository.findByRoomId(roomId).orElse(null);
+			String resumeOcr = ocrResult != null ? ocrResult.getResumeOcr() : "";
+			String jobPostingOcr = ocrResult != null ? ocrResult.getJobPostingOcr() : "";
+
+			context = new FastApiChatContext(
+				"interview",
+				resumeOcr,
+				jobPostingOcr,
+				interview.getInterviewType().name().toLowerCase(),
+				interview.getCurrentQuestionCount()
+			);
+		}
+
+		MessageType messageType = interviewId != null ? MessageType.INTERVIEW : MessageType.NORMAL;
+		AiChatInterview finalInterview = interview;
+
+		saveUserMessage(room, content, messageType, interview);
 
 		FastApiChatRequest request = new FastApiChatRequest(
 			model.name().toLowerCase(),
 			roomId,
 			userId,
 			content,
-			null,
-			FastApiChatContext.createNormalMode()
+			interviewId,
+			context
 		);
 
 		StringBuilder fullResponse = new StringBuilder();
@@ -84,7 +117,7 @@ public class AiChatMessageService {
 			})
 			.doOnComplete(() -> {
 				if (!hasError.get()) {
-					saveAssistantMessage(room, fullResponse.toString(), model);
+					saveAssistantMessage(room, fullResponse.toString(), model, messageType, finalInterview);
 					log.info("AI 챗봇 스트리밍 완료: roomId={}, totalLength={}",
 						LogSanitizer.sanitize(String.valueOf(roomId)),
 						fullResponse.length());
@@ -99,18 +132,20 @@ public class AiChatMessageService {
 					metadata.put("model", model.name());
 					metadata.put("incomplete", true);
 					metadata.put("error", e.getMessage());
-					saveAssistantMessage(room, fullResponse.toString(), metadata);
+					saveAssistantMessage(room, fullResponse.toString(), metadata, messageType, finalInterview);
 				}
 			})
 			.onErrorResume(e -> Flux.just("ERROR:" + e.getMessage()));
 	}
 
 	@Transactional
-	public AiChatMessage saveUserMessage(AiChatRoom room, String content) {
+	public AiChatMessage saveUserMessage(AiChatRoom room, String content, MessageType type,
+		AiChatInterview interview) {
 		AiChatMessage message = AiChatMessage.builder()
 			.room(room)
+			.interview(interview)
 			.role(MessageRole.USER)
-			.type(MessageType.NORMAL)
+			.type(type)
 			.content(content)
 			.metadata(null)
 			.build();
@@ -119,19 +154,22 @@ public class AiChatMessageService {
 	}
 
 	@Transactional
-	public AiChatMessage saveAssistantMessage(AiChatRoom room, String content, AiModel model) {
+	public AiChatMessage saveAssistantMessage(AiChatRoom room, String content, AiModel model, MessageType type,
+		AiChatInterview interview) {
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("model", model.name());
 
-		return saveAssistantMessage(room, content, metadata);
+		return saveAssistantMessage(room, content, metadata, type, interview);
 	}
 
 	@Transactional
-	public AiChatMessage saveAssistantMessage(AiChatRoom room, String content, Map<String, Object> metadata) {
+	public AiChatMessage saveAssistantMessage(AiChatRoom room, String content, Map<String, Object> metadata,
+		MessageType type, AiChatInterview interview) {
 		AiChatMessage message = AiChatMessage.builder()
 			.room(room)
+			.interview(interview)
 			.role(MessageRole.ASSISTANT)
-			.type(MessageType.NORMAL)
+			.type(type)
 			.content(content)
 			.metadata(metadata)
 			.build();

--- a/src/main/java/com/ktb3/devths/global/response/ErrorCode.java
+++ b/src/main/java/com/ktb3/devths/global/response/ErrorCode.java
@@ -37,11 +37,13 @@ public enum ErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
 	AI_CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 AI 채팅방을 찾을 수 없습니다"),
 	ASYNC_TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "비동기 작업을 찾을 수 없습니다"),
+	INTERVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "면접을 찾을 수 없습니다"),
 
 	// 409 Conflict
 	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다"),
 	DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다"),
 	DUPLICATE_ANALYSIS(HttpStatus.CONFLICT, "이미 진행 중인 분석 작업이 있습니다"),
+	INTERVIEW_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "이미 진행 중인 면접이 있습니다"),
 
 	// 500 Internal Server Error
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다"),


### PR DESCRIPTION
## 📌 작업한 내용
- 면접 모드 시작 및 종료 API 구현

## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#66 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인