### PR TITLE
fix: FastAPI에서 S3Key 접근 불가능 문제 해결 (#70)

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/analysis/service/AsyncAnalysisProcessor.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/service/AsyncAnalysisProcessor.java
@@ -25,6 +25,7 @@ import com.ktb3.devths.global.exception.CustomException;
 import com.ktb3.devths.global.response.ErrorCode;
 import com.ktb3.devths.global.storage.domain.entity.S3Attachment;
 import com.ktb3.devths.global.storage.repository.S3AttachmentRepository;
+import com.ktb3.devths.global.storage.service.S3StorageService;
 import com.ktb3.devths.global.util.LogSanitizer;
 
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,7 @@ public class AsyncAnalysisProcessor {
 	private final AiChatRoomRepository aiChatRoomRepository;
 	private final S3AttachmentRepository s3AttachmentRepository;
 	private final AiOcrResultService aiOcrResultService;
+	private final S3StorageService s3StorageService;
 
 	@Async("taskExecutor")
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -110,9 +112,11 @@ public class AsyncAnalysisProcessor {
 			fileType = attachment.getMimeType();
 		}
 
+		String publicUrl = s3StorageService.getPublicUrl(s3Key);
+
 		return new FastApiAnalysisRequest.FastApiDocumentInfo(
 			fileId,
-			s3Key,
+			publicUrl,
 			fileType,
 			documentInfo.text()
 		);


### PR DESCRIPTION
## 📌 작업한 내용
- FastAPI로 전달하면 s3Key를 public url로 변경
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#70 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인