### PR TITLE
fix: FastAPI 폴링 중 timeout 해결

### DIFF
--- a/src/main/java/com/ktb3/devths/global/config/RestClientConfig.java
+++ b/src/main/java/com/ktb3/devths/global/config/RestClientConfig.java
@@ -1,14 +1,34 @@
 package com.ktb3.devths.global.config;
 
+import java.time.Duration;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
+import com.ktb3.devths.global.config.properties.FastApiProperties;
+
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 public class RestClientConfig {
+
+	private final FastApiProperties fastApiProperties;
 
 	@Bean
 	public RestClient restClient() {
-		return RestClient.builder().build();
+		return RestClient.builder()
+			.requestFactory(clientHttpRequestFactory())
+			.build();
+	}
+
+	private ClientHttpRequestFactory clientHttpRequestFactory() {
+		SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+		factory.setConnectTimeout(Duration.ofMillis(fastApiProperties.getTimeout()));
+		factory.setReadTimeout(Duration.ofMillis(fastApiProperties.getTimeout()));
+		return factory;
 	}
 }


### PR DESCRIPTION
## 📌 작업한 내용
- RestClientConfig에 timeout 설정 추가
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#70 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인