### PR TITLE
fix: content 필드 타입 TEXT로 변경 (#70)

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/chatbot/domain/entity/AiChatMessage.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/domain/entity/AiChatMessage.java
@@ -53,7 +53,7 @@ public class AiChatMessage {
 	@Enumerated(EnumType.STRING)
 	private MessageRole role;
 
-	@Column(name = "content", nullable = false)
+	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
 	private String content;
 
 	@Column(name = "created_at", nullable = false)


### PR DESCRIPTION
## 📌 작업한 내용
- content 필드 저장 시 value too long 문제 해결하기 위해 타입을 TEXT로 변경

## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#70 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인