### PR TITLE
fix: OCR 저장 시 value too long 해결을 위해 TEXT 타입으로 컬럼 변경

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/analysis/domain/AiOcrResult.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/domain/AiOcrResult.java
@@ -31,9 +31,9 @@ public class AiOcrResult {
 	@JoinColumn(name = "room_id")
 	private AiChatRoom room;
 
-	@Column(name = "resume_ocr", nullable = false)
+	@Column(name = "resume_ocr", nullable = false, columnDefinition = "TEXT")
 	private String resumeOcr;
 
-	@Column(name = "job_posting_ocr", nullable = false)
+	@Column(name = "job_posting_ocr", nullable = false, columnDefinition = "TEXT")
 	private String jobPostingOcr;
 }


### PR DESCRIPTION
## 📌 작업한 내용
- OCR 저장 필드 타입 TEXT로 변경
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인