### PR TITLE
fix: 회원 정보 수정 및 탈퇴 시 오류 수정 (#89)

### DIFF
--- a/src/main/java/com/ktb3/devths/user/controller/UserController.java
+++ b/src/main/java/com/ktb3/devths/user/controller/UserController.java
@@ -73,9 +73,12 @@ public class UserController {
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204")
 	@DeleteMapping
 	public ResponseEntity<Void> withdraw(
-		@AuthenticationPrincipal UserPrincipal userPrincipal
+		@AuthenticationPrincipal UserPrincipal userPrincipal,
+		HttpServletResponse response
 	) {
 		userService.withdraw(userPrincipal.getUserId());
+
+		response.addCookie(CookieUtil.clearRefreshTokenCookie());
 
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/ktb3/devths/user/repository/UserInterestRepository.java
+++ b/src/main/java/com/ktb3/devths/user/repository/UserInterestRepository.java
@@ -3,6 +3,7 @@ package com.ktb3.devths.user.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,5 +14,7 @@ public interface UserInterestRepository extends JpaRepository<UserInterest, Long
 	@Query("SELECT ui.interest FROM UserInterest ui WHERE ui.user.id = :userId")
 	List<Interests> findInterestsByUserId(@Param("userId") Long userId);
 
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM UserInterest ui WHERE ui.user.id = :userId")
 	void deleteAllByUser_Id(Long userId);
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 회원 정보 수정 시 관심 분야 수정 로직 변경
- 회원 탈퇴 시 Set-Cookie maxAge=0을 통해 쿠키 삭제 로직 추가

## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#89 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인