### PR TITLE
fix: 닉네임과 관심사항 변경 시 닉네임 변경 누락 해결 (#89)

### DIFF
--- a/src/main/java/com/ktb3/devths/user/repository/UserInterestRepository.java
+++ b/src/main/java/com/ktb3/devths/user/repository/UserInterestRepository.java
@@ -14,7 +14,7 @@ public interface UserInterestRepository extends JpaRepository<UserInterest, Long
 	@Query("SELECT ui.interest FROM UserInterest ui WHERE ui.user.id = :userId")
 	List<Interests> findInterestsByUserId(@Param("userId") Long userId);
 
-	@Modifying(clearAutomatically = true)
+	@Modifying(clearAutomatically = false)
 	@Query("DELETE FROM UserInterest ui WHERE ui.user.id = :userId")
 	void deleteAllByUser_Id(Long userId);
 }


### PR DESCRIPTION
## 📌 작업한 내용
- `@Modifying(clearAutomatically = true)`를 `@Modifying(clearAutomatically = false)`로 변경
## 🔍 참고 사항
`clearAutomatically = true`는 DELETE 후 영속성 컨텍스트를 전부 비움
→ user의 변경 사항(닉네임)이 영속성 컨텍스트에만 일단 저장됐다가, 그 뒤에 interests를 업데이트 하면서 deleteAllByUser_Id가 호출, `clearAutomatically = true` 때문에 영속성 컨텍스트가 비워지므로 닉네임 변경 사항이 적용되지 않았던 것

## 🖼️ 스크린샷

## 🔗 관련 이슈

#89 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인