### PR TITLE
fix: s3Key가 null임에도 public url 생성하던 문제 해결

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/analysis/service/AsyncAnalysisProcessor.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/service/AsyncAnalysisProcessor.java
@@ -114,7 +114,7 @@ public class AsyncAnalysisProcessor {
 			fileType = attachment.getMimeType();
 		}
 
-		String publicUrl = s3StorageService.getPublicUrl(s3Key);
+		String publicUrl = (s3Key != null) ? s3StorageService.getPublicUrl(s3Key) : null;
 
 		return new FastApiAnalysisRequest.FastApiDocumentInfo(
 			fileId,


### PR DESCRIPTION
## 📌 작업한 내용
- s3Key가 null인지 확인하고 생성하게 로직 변경

## 🔍 참고 사항
## 🖼️ 스크린샷
## 🔗 관련 이슈
## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인