### PR TITLE
[#96] chore: CloudWatch로 메트릭 전송하는 Config 추가

### DIFF
--- a/src/main/java/com/ktb3/devths/global/config/CloudWatchConfig.java
+++ b/src/main/java/com/ktb3/devths/global/config/CloudWatchConfig.java
@@ -1,0 +1,22 @@
+package com.ktb3.devths.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+
+@Configuration
+public class CloudWatchConfig {
+
+	@Value("${cloud.aws.region.static-region}")
+	private String awsRegion;
+
+	@Bean
+	public CloudWatchAsyncClient cloudWatchAsyncClient() {
+		return CloudWatchAsyncClient.builder()
+			.region(Region.of(awsRegion))
+			.build();
+	}
+}


### PR DESCRIPTION
## 📌 작업한 내용
Micrometer를 통해 수집된 애플리케이션 메트릭스를 AWS CloudWatch로 자동 전송하도록 설정 파일을 추가했습니다 HikariCP 커넥션 풀 상태, HTTP 요청 통계 등이 CloudWatch Metrics로 전송됩니다.

## 🔍 참고 사항
- 최대한 Config를 안넣고 싶었는데, 현재 사용중이신 `'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'` 의존성에서는 필요하다고 해서 추가했습니다..

## 🖼️ 스크린샷
(해당 없음)

## 🔗 관련 이슈
#96

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인