### PR TITLE
fix: ServerSentEvent 타입을 사용하여 자동 파싱으로 변경 (#106)

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/client/FastApiClient.java
+++ b/src/main/java/com/ktb3/devths/ai/client/FastApiClient.java
@@ -90,7 +90,8 @@ public class FastApiClient {
 			.accept(MediaType.TEXT_EVENT_STREAM)
 			.bodyValue(request)
 			.retrieve()
-			.bodyToFlux(new org.springframework.core.ParameterizedTypeReference<ServerSentEvent<String>>() {})
+			.bodyToFlux(new org.springframework.core.ParameterizedTypeReference<ServerSentEvent<String>>() {
+			})
 			.mapNotNull(sse -> {
 				String data = sse.data();
 				if (data == null) {
@@ -115,7 +116,8 @@ public class FastApiClient {
 			.accept(MediaType.TEXT_EVENT_STREAM)
 			.bodyValue(request)
 			.retrieve()
-			.bodyToFlux(new org.springframework.core.ParameterizedTypeReference<ServerSentEvent<String>>() {})
+			.bodyToFlux(new org.springframework.core.ParameterizedTypeReference<ServerSentEvent<String>>() {
+			})
 			.mapNotNull(sse -> {
 				String data = sse.data();
 				if (data == null) {


### PR DESCRIPTION
## 📌 작업한 내용
- ServerSentEvent 타입을 사용하여 자동 파싱되게 로직 수정(`FastApiClient.java`)
## 🔍 참고 사항
## 🖼️ 스크린샷
## 🔗 관련 이슈

#106 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인