### PR TITLE
[#96] fix: YML에서 DB커넥션만 열리도록 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,11 @@ management:
     health:
       show-details: never
   metrics:
+    enable:
+      # 모든 메트릭 비활성화
+      all: false
+      # Hikari 커넥션 풀만 활성화
+      hikaricp: true
     export:
       cloudwatch:
         namespace: ${CW_NAME_SPACE:devths-local}


### PR DESCRIPTION
## 📌 작업한 내용
YML 설정에서 DB 커넥션(HikariCP)만 모니터링되도록 수정했습니다. 불필요한 모든 JMX MBean 등록을 제거하고, `hikaricp.*` 패턴만 선택적으로 활성화하여 DB 풀 상태만 노출되도록 변경했습니다.
EC2 커스텀 모니터링마다 돈이 부과된다고 해서 최소한으로 수정했습니다!

## 🔍 참고 사항
- 변경 후 DB 연결 풀의 active/idle/waiting 등의 핵심 지표만 수집됩니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
#96

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인