### PR TITLE
fix: AI 채팅방 재입장 시 마지막(최신) 메시지 누락 현상 해결

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/chatbot/dto/response/AiChatMessageListResponse.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/dto/response/AiChatMessageListResponse.java
@@ -1,5 +1,6 @@
 package com.ktb3.devths.ai.chatbot.dto.response;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.ktb3.devths.ai.chatbot.domain.entity.AiChatMessage;
@@ -16,7 +17,11 @@ public record AiChatMessageListResponse(
 			? chatMessages.subList(0, requestedSize)
 			: chatMessages;
 
-		List<AiChatMessageResponse> messages = actualMessages.stream()
+		// DESC로 조회했으므로 reverse하여 ASC 순서로 변환
+		List<AiChatMessage> ordered = new java.util.ArrayList<>(actualMessages);
+		Collections.reverse(ordered);
+
+		List<AiChatMessageResponse> messages = ordered.stream()
 			.map(AiChatMessageResponse::from)
 			.toList();
 

--- a/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatRoomService.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatRoomService.java
@@ -1,6 +1,5 @@
 package com.ktb3.devths.ai.chatbot.service;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.springframework.data.domain.PageRequest;
@@ -80,9 +79,6 @@ public class AiChatRoomService {
 		List<AiChatMessage> messages = (lastId == null)
 			? aiChatMessageRepository.findByRoomIdOrderByIdDesc(roomId, pageable)
 			: aiChatMessageRepository.findByRoomIdAndIdLessThanOrderByIdDesc(roomId, lastId, pageable);
-
-		// DESC로 조회했으므로 reverse하여 ASC 순서로 변환
-		Collections.reverse(messages);
 
 		return AiChatMessageListResponse.of(messages, pageSize);
 	}


### PR DESCRIPTION
## 📌 작업한 내용
- `Collections.reverse()` 위치를 DTO의 `of` 메서드 내부로 옮겨 최신 메시지가 누락되는 현상 방지
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인