### PR TITLE
fix: 면접 모드 종료 시 불필요한 6번째 질문 생성 방지를 위한 개수 체크 로직 추가 (#136)

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatMessageService.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatMessageService.java
@@ -83,6 +83,12 @@ public class AiChatMessageService {
 			interview = aiChatInterviewRepository.findById(interviewId)
 				.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
 
+			// 5개 질문 제한 체크
+			if (interview.getCurrentQuestionCount() >= 5) {
+				interview.complete();
+				throw new CustomException(ErrorCode.INTERVIEW_COMPLETED_EVALUATION_REQUIRED);
+			}
+
 			interview.incrementQuestionCount();
 
 			AiOcrResult ocrResult = aiOcrResultRepository.findByRoomId(roomId).orElse(null);

--- a/src/main/java/com/ktb3/devths/global/response/ErrorCode.java
+++ b/src/main/java/com/ktb3/devths/global/response/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 	INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드입니다"),
 	INVALID_FILE_REFERENCE(HttpStatus.BAD_REQUEST, "유효하지 않은 파일 참조입니다"),
 	INVALID_EVENT_TIME(HttpStatus.BAD_REQUEST, "일정 시작 시간은 종료 시간보다 이전이어야 합니다"),
+	INTERVIEW_COMPLETED_EVALUATION_REQUIRED(HttpStatus.BAD_REQUEST, "면접 질문 5개가 완료되었습니다. 평가를 진행해주세요."),
 
 	// 401 Unauthorized
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),


### PR DESCRIPTION
## 📌 작업한 내용
- 면접 모드 종료 시 불필요한 6번째 질문 생성 방지를 위한 질문 개수 체크 로직 추가
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#136 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인