### PR TITLE
feat: 채팅방 바로 입장 시에도 분석 완료 알림 읽음 처리 로직 추가 (#150)

### DIFF
--- a/src/main/java/com/ktb3/devths/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ktb3/devths/notification/repository/NotificationRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.ktb3.devths.notification.domain.constant.NotificationCategory;
+import com.ktb3.devths.notification.domain.constant.NotificationType;
 import com.ktb3.devths.notification.domain.entity.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
@@ -43,4 +45,17 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 		+ "AND n.isRead = false "
 		+ "AND n.isDeleted = false")
 	Long countUnreadByRecipientId(@Param("recipientId") Long recipientId);
+
+	@Modifying
+	@Query("UPDATE Notification n SET n.isRead = true "
+		+ "WHERE n.resourceId = :roomId "
+		+ "AND n.category = :category "
+		+ "AND n.type = :type "
+		+ "AND n.isRead = false "
+		+ "AND n.isDeleted = false")
+	int markAsReadByRoomIdAndCategoryAndType(
+		@Param("roomId") Long roomId,
+		@Param("category") NotificationCategory category,
+		@Param("type") NotificationType type
+	);
 }

--- a/src/main/java/com/ktb3/devths/notification/service/NotificationService.java
+++ b/src/main/java/com/ktb3/devths/notification/service/NotificationService.java
@@ -74,4 +74,16 @@ public class NotificationService {
 		Long count = notificationRepository.countUnreadByRecipientId(userId);
 		return UnreadCountResponse.of(count);
 	}
+
+	@Transactional
+	public void markReportNotificationAsReadByRoomId(Long roomId) {
+		int updated = notificationRepository.markAsReadByRoomIdAndCategoryAndType(
+			roomId,
+			NotificationCategory.AI,
+			NotificationType.REPORT
+		);
+		if (updated > 0) {
+			log.info("채팅방 입장으로 알림 읽음 처리");
+		}
+	}
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 이력서/채용 공고 분석 결과 알림을 알림 센터에서 확인하지 않고 해당 채팅방에 바로 입장 시에도 읽음 처리 되게 로직 추가
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈
#150 
## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인