### PR TITLE
fix: DocumentAnalysisRequest DTO에 cascade Valid 어노테이션 적용

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/analysis/dto/request/DocumentAnalysisRequest.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/dto/request/DocumentAnalysisRequest.java
@@ -22,7 +22,7 @@ public record DocumentAnalysisRequest(
 		Long fileId,
 		String s3Key,
 		String fileType,
-		@Size(min = 1, max = 2000)
+		@Size(max = 2000)
 		String text
 	) {
 		public boolean hasFileReference() {


### PR DESCRIPTION
## 📌 작업한 내용
- Record의 cascading으로 인해 하위 record의 `@Size`가 validation 되지 않던 문제 해결
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인