### PR TITLE
fix: 댓글 수정 DTO validation  추가

### DIFF
--- a/src/main/java/com/ktb3/devths/board/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/ktb3/devths/board/dto/request/CommentUpdateRequest.java
@@ -1,9 +1,11 @@
 package com.ktb3.devths.board.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record CommentUpdateRequest(
 	@NotBlank(message = "댓글 내용은 필수입니다")
+	@Size(min = 1, max = 500, message = "댓글은 최대 500자까지 작성 가능합니다")
 	String content
 ) {
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 댓글 수정 dto(`CommentUpdateRequest`)에 누락되어 있던 `content` 필드 validation을 추가하였습니다.
## 🔍 참고 사항


## 🖼️ 스크린샷


## 🔗 관련 이슈


## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인