### PR TITLE
fix: 알림 커밋 실패로 인한 알림 센터 누락 문제 해결 (#175)

### DIFF
--- a/src/main/java/com/ktb3/devths/notification/service/NotificationService.java
+++ b/src/main/java/com/ktb3/devths/notification/service/NotificationService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ktb3.devths.notification.domain.constant.NotificationCategory;
@@ -30,7 +31,7 @@ public class NotificationService {
 	private final NotificationRepository notificationRepository;
 	private final UserRepository userRepository;
 
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public Notification createAnalysisCompleteNotification(User recipient, Long roomId, String summary) {
 		Notification notification = Notification.builder()
 			.recipient(recipient)
@@ -49,7 +50,7 @@ public class NotificationService {
 		return savedNotification;
 	}
 
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public Notification createFollowNotification(User recipient, Long senderId, String senderNickname) {
 		Notification notification = Notification.builder()
 			.recipient(recipient)
@@ -68,7 +69,7 @@ public class NotificationService {
 		return savedNotification;
 	}
 
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public Notification createPostCommentNotification(
 		User recipient,
 		Long senderId,
@@ -99,7 +100,7 @@ public class NotificationService {
 		return savedNotification;
 	}
 
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public Notification createCommentReplyNotification(
 		User recipient,
 		Long senderId,


### PR DESCRIPTION
## 📌 작업한 내용
- NotificationService의 알림 생성 메서드들에 `@Transactional(propagation = Propagation.REQUIRES_NEW)`를 적용하여 이벤트 리스너에서 호출될 때 새로운 트랜잭션을 생성, 알림 엔티티가 DB에 실제로 커밋되게 변경하였습니다.
## 🔍 참고 사항


## 🖼️ 스크린샷


## 🔗 관련 이슈

#175 
## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인