### PR TITLE
fix: 알림 라우팅 주소 오류 해결 (#175)

### DIFF
--- a/src/main/java/com/ktb3/devths/notification/service/NotificationService.java
+++ b/src/main/java/com/ktb3/devths/notification/service/NotificationService.java
@@ -83,7 +83,7 @@ public class NotificationService {
 			.category(NotificationCategory.BOARD)
 			.type(NotificationType.COMMENT)
 			.content(senderNickname + "님이 회원님의 게시물에 댓글을 남겼습니다.")
-			.targetPath("/posts/" + postId)
+			.targetPath("/board/" + postId)
 			.resourceId(postId)
 			.isRead(false)
 			.build();
@@ -114,7 +114,7 @@ public class NotificationService {
 			.category(NotificationCategory.BOARD)
 			.type(NotificationType.COMMENT)
 			.content(senderNickname + "님이 회원님의 댓글에 답글을 남겼습니다.")
-			.targetPath("/posts/" + postId)
+			.targetPath("/board/" + postId)
 			.resourceId(postId)
 			.isRead(false)
 			.build();


### PR DESCRIPTION
## 📌 작업한 내용
- 알림의 `targetPath` 필드의 라우팅 주소가 잘못 기입되던 로직을 수정했습니다.
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

#175 
## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인