### PR TITLE
refactor: FollowService 내부 N+1 문제를 배치 조회로 해결 (#142)

### DIFF
--- a/src/main/java/com/ktb3/devths/user/service/FollowService.java
+++ b/src/main/java/com/ktb3/devths/user/service/FollowService.java
@@ -1,7 +1,9 @@
 package com.ktb3.devths.user.service;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.dao.DataIntegrityViolationException;
@@ -153,13 +155,12 @@ public class FollowService {
 			? new HashSet<>()
 			: new HashSet<>(followRepository.findFollowingIdsByFollowerIdAndFollowingIdIn(userId, followerUserIds));
 
+		Map<Long, String> profileImageUrlMap = buildProfileImageUrlMap(followerUserIds);
+
 		List<FollowerSummaryResponse> followers = actualFollows.stream()
 			.map(f -> {
 				User follower = f.getFollower();
-				String profileImageUrl = s3AttachmentRepository
-					.findTopByRefTypeAndRefIdAndIsDeletedFalseOrderByCreatedAtDesc(RefType.USER, follower.getId())
-					.map(attachment -> s3StorageService.getPublicUrl(attachment.getS3Key()))
-					.orElse(null);
+				String profileImageUrl = profileImageUrlMap.get(follower.getId());
 
 				return new FollowerSummaryResponse(
 					f.getId(),
@@ -194,13 +195,16 @@ public class FollowService {
 			? follows.subList(0, pageSize)
 			: follows;
 
+		List<Long> followingUserIds = actualFollows.stream()
+			.map(f -> f.getFollowing().getId())
+			.toList();
+
+		Map<Long, String> profileImageUrlMap = buildProfileImageUrlMap(followingUserIds);
+
 		List<FollowerSummaryResponse> followings = actualFollows.stream()
 			.map(f -> {
 				User following = f.getFollowing();
-				String profileImageUrl = s3AttachmentRepository
-					.findTopByRefTypeAndRefIdAndIsDeletedFalseOrderByCreatedAtDesc(RefType.USER, following.getId())
-					.map(attachment -> s3StorageService.getPublicUrl(attachment.getS3Key()))
-					.orElse(null);
+				String profileImageUrl = profileImageUrlMap.get(following.getId());
 
 				return new FollowerSummaryResponse(
 					f.getId(),
@@ -235,5 +239,20 @@ public class FollowService {
 				User user = userRepository.getReferenceById(userId);
 				return userStatRepository.save(UserStat.builder().user(user).build());
 			});
+	}
+
+	private Map<Long, String> buildProfileImageUrlMap(List<Long> userIds) {
+		if (userIds.isEmpty()) {
+			return Map.of();
+		}
+
+		Map<Long, String> profileImageUrlMap = new HashMap<>();
+		s3AttachmentRepository.findByRefTypeAndRefIdInAndIsDeletedFalse(RefType.USER, userIds)
+			.forEach(attachment -> profileImageUrlMap.putIfAbsent(
+				attachment.getRefId(),
+				s3StorageService.getPublicUrl(attachment.getS3Key())
+			));
+
+		return profileImageUrlMap;
 	}
 }


### PR DESCRIPTION
## 📌 작업한 내용
- `FollowService` 내부 리스트 순회로 인한 N+1 문제를 해결하였습니다.
- userIds를 모아 `findByRefTypeAndRefIdInAndIsDeletedFalse(...)` 1회 조회 후 `Map<userId, profileImage>`로 매핑해서 DTO 변환 시 사용하게 변경했습니다.
- 팔로워(또는 팔로잉)가 N명이어도 N+1 문제가 발생하지 않고 고정된 횟수만큼만 쿼리가 발생합니다.
  - 팔로워 조회 시 : N+2회(follows 1회 + followingBackIds 1회 + 프로필 이미지 N회) -> 3회(follows 1회 + followingBackIds 1회 + 프로필 이미지 IN 조회 1회)
  - 팔로잉 조회 시 : N+1회(follows 1회 + 프로필 이미지 N회) -> 2회(follows 1회 + 프로필 이미지 IN 조회 1회)
## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인