### PR TITLE
refactor: 면접 평가 엔드포인트 변경 (#178)

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/chatbot/controller/AiChatRoomController.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/controller/AiChatRoomController.java
@@ -211,7 +211,8 @@ public class AiChatRoomController {
 			throw new CustomException(ErrorCode.AI_CHATROOM_ACCESS_DENIED);
 		}
 
-		Flux<String> evaluationStream = aiChatInterviewService.evaluateInterview(request.interviewId());
+		boolean retry = request.retry() != null && request.retry();
+		Flux<String> evaluationStream = aiChatInterviewService.evaluateInterview(request.interviewId(), retry);
 
 		return evaluationStream
 			.map(chunk -> {

--- a/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/FastApiInterviewEvaluationRequest.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/FastApiInterviewEvaluationRequest.java
@@ -5,23 +5,26 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record FastApiInterviewEvaluationRequest(
-	@JsonProperty("interview_id")
-	Long interviewId,
-
-	@JsonProperty("interview_type")
-	String interviewType,
-
-	@JsonProperty("room_id")
-	Long roomId,
-
-	@JsonProperty("user_id")
-	Long userId,
-
-	List<FastApiInterviewMessage> messages
+	String name,
+	Value value
 ) {
-	public record FastApiInterviewMessage(
-		String role,
-		String content
+	public record Value(
+		List<ContextEntry> context,
+		boolean retry,
+		@JsonProperty("room_id")
+		Long roomId,
+		@JsonProperty("session_id")
+		Long sessionId,
+		@JsonProperty("user_id")
+		Long userId,
+		@JsonProperty("interview_type")
+		String interviewType
+	) {
+	}
+
+	public record ContextEntry(
+		String question,
+		String answer
 	) {
 	}
 }

--- a/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/InterviewEvaluationRequest.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/dto/request/InterviewEvaluationRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record InterviewEvaluationRequest(
 	@NotNull(message = "면접 ID는 필수입니다")
-	Long interviewId
+	Long interviewId,
+	Boolean retry
 ) {
 }

--- a/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatInterviewService.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatInterviewService.java
@@ -90,7 +90,7 @@ public class AiChatInterviewService {
 		return aiChatInterviewRepository.findByRoomIdAndStatus(roomId, InterviewStatus.IN_PROGRESS);
 	}
 
-	public Flux<String> evaluateInterview(Long interviewId) {
+	public Flux<String> evaluateInterview(Long interviewId, boolean retry) {
 		// 현재 스레드의 Authentication 캡처 (여기서는 SecurityContext가 존재함)
 		Authentication currentAuth = SecurityContextHolder.getContext().getAuthentication();
 
@@ -99,33 +99,44 @@ public class AiChatInterviewService {
 
 		List<AiChatMessage> messages = aiChatMessageRepository.findAll().stream()
 			.filter(msg -> msg.getInterview() != null && msg.getInterview().getId().equals(interviewId))
+			.sorted((a, b) -> a.getId().compareTo(b.getId()))
 			.collect(Collectors.toList());
 
 		if (messages.isEmpty()) {
 			throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
 		}
 
-		List<FastApiInterviewEvaluationRequest.FastApiInterviewMessage> interviewMessages = messages.stream()
-			.map(msg -> new FastApiInterviewEvaluationRequest.FastApiInterviewMessage(
-				msg.getRole().name().toLowerCase(),
-				msg.getContent()
-			))
-			.collect(Collectors.toList());
+		// ASSISTANT(질문) → USER(답변) 순서로 페어링하여 Q&A 쌍 생성
+		List<FastApiInterviewEvaluationRequest.ContextEntry> context = new java.util.ArrayList<>();
+		for (int i = 0; i < messages.size() - 1; i++) {
+			AiChatMessage current = messages.get(i);
+			AiChatMessage next = messages.get(i + 1);
+			if (current.getRole() == MessageRole.ASSISTANT && next.getRole() == MessageRole.USER) {
+				context.add(new FastApiInterviewEvaluationRequest.ContextEntry(
+					current.getContent(),
+					next.getContent()
+				));
+			}
+		}
 
 		// roomId와 userId 추출
 		Long roomId = room.getId();
 		Long userId = room.getUser().getId();
 
 		FastApiInterviewEvaluationRequest request = new FastApiInterviewEvaluationRequest(
-			interviewId,
-			interview.getInterviewType().name().toLowerCase(),
-			roomId,
-			userId,
-			interviewMessages
+			"면접 리포트 생성 (면접 종료)",
+			new FastApiInterviewEvaluationRequest.Value(
+				context,
+				retry,
+				roomId,
+				interviewId,
+				userId,
+				interview.getInterviewType().name().toLowerCase()
+			)
 		);
 
-		log.info("면접 평가 시작: interviewId={}, roomId={}, userId={}, messageCount={}",
-			interviewId, roomId, userId, messages.size());
+		log.info("면접 평가 시작: interviewId={}, roomId={}, userId={}, contextCount={}",
+			interviewId, roomId, userId, context.size());
 
 		// 전체 평가 결과 누적용
 		StringBuilder fullEvaluation = new StringBuilder();

--- a/src/main/java/com/ktb3/devths/ai/client/FastApiClient.java
+++ b/src/main/java/com/ktb3/devths/ai/client/FastApiClient.java
@@ -118,15 +118,15 @@ public class FastApiClient {
 	}
 
 	public Flux<String> streamInterviewEvaluation(FastApiInterviewEvaluationRequest request) {
-		rateLimitService.consumeToken(request.userId(), ApiType.FASTAPI_ANALYSIS);
+		rateLimitService.consumeToken(request.value().userId(), ApiType.FASTAPI_ANALYSIS);
 
-		String url = fastApiProperties.getBaseUrl() + "/ai/chat";
+		String url = fastApiProperties.getBaseUrl() + "/ai/evaluation/analyze";
 
 		// 메타데이터만 로깅 (민감 정보 제외)
-		log.info("면접 평가 요청 - interviewId={}, type={}, messageCount={}",
-			LogSanitizer.sanitize(String.valueOf(request.interviewId())),
-			request.interviewType(),
-			request.messages().size());
+		log.info("면접 평가 요청 - sessionId={}, type={}, contextCount={}",
+			LogSanitizer.sanitize(String.valueOf(request.value().sessionId())),
+			request.value().interviewType(),
+			request.value().context().size());
 
 		return webClient.post()
 			.uri(url)


### PR DESCRIPTION
## 📌 작업한 내용
- 면접 평가를 요청하는 FastAPI의 엔드포인트를 `/ai/chat`에서 `/ai/evaluation/analyze`로 변경하였습니다.
  - 이에 따른 요청/응답 DTO의 변경 사항 또한 반영하였습니다.
## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

#178 
## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인