### PR TITLE
fix: 내 팔로잉 목록 조회 시 500 에러 발생 해결 (#185)

### DIFF
--- a/src/main/java/com/ktb3/devths/user/repository/FollowRepository.java
+++ b/src/main/java/com/ktb3/devths/user/repository/FollowRepository.java
@@ -25,10 +25,10 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 	List<Long> findFollowingIdsByFollowerIdAndFollowingIdIn(@Param("followerId") Long followerId, @Param("followingIds") List<Long> followingIds);
 
 	@Query("SELECT f FROM Follow f JOIN FETCH f.following WHERE f.follower.id = :userId AND f.following.isWithdraw = false "
-		+ "AND (:nickname IS NULL OR f.following.nickname LIKE CONCAT('%', :nickname, '%')) ORDER BY f.id DESC")
+		+ "AND (:nickname IS NULL OR f.following.nickname LIKE CONCAT('%', CAST(:nickname AS string), '%')) ORDER BY f.id DESC")
 	List<Follow> findFollowingsByUserId(@Param("userId") Long userId, @Param("nickname") String nickname, Pageable pageable);
 
 	@Query("SELECT f FROM Follow f JOIN FETCH f.following WHERE f.follower.id = :userId AND f.following.isWithdraw = false "
-		+ "AND (:nickname IS NULL OR f.following.nickname LIKE CONCAT('%', :nickname, '%')) AND f.id < :lastId ORDER BY f.id DESC")
+		+ "AND (:nickname IS NULL OR f.following.nickname LIKE CONCAT('%', CAST(:nickname AS string), '%')) AND f.id < :lastId ORDER BY f.id DESC")
 	List<Follow> findFollowingsByUserIdAfterCursor(@Param("userId") Long userId, @Param("nickname") String nickname, @Param("lastId") Long lastId, Pageable pageable);
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 내 팔로잉 목록 조회 시 500 에러가 발생하던 문제를 해결하였습니다.
  - `FollowRepository`의 `findFollowingByUserId` 메서드는 내 팔로잉 목록 조회 뿐만 아니라 추후 팔로잉 검색에도 사용되기 때문에 파라미터로 nickname을 받습니다.
  - '내 팔로잉 목록 조회' 시에는 nickname이 null인데, 이때 PostgreSQL 드라이버가 해당 파라미터의 타입을 varchar가 아닌 bytea로 추론하게 되고, varchar LIKE bytea 조합이 되어 "operator does not exist" 에러가 발생하였습니다.
  - `CAST(:nickname AS string)` 구문을 추가해 드라이버가 nickname 파라미터의 타입을 varchar로 추론할 수 있게 캐스팅해주었습니다.

- 정리 : 선택적으로 받는 쿼리 파라미터의 타입 추론 문제로 인한 operator does not exist 문제를 CAST 구문을 통해 해결
## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

#185 
## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인