### PR TITLE
fix: 이력서 분석과 챗봇 응답/면접 평가의 Rate Limit 버킷 용량 분리 (#190)

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/client/FastApiClient.java
+++ b/src/main/java/com/ktb3/devths/ai/client/FastApiClient.java
@@ -90,7 +90,7 @@ public class FastApiClient {
 	}
 
 	public Flux<String> streamChatResponse(FastApiChatRequest request) {
-		rateLimitService.consumeToken(request.userId(), ApiType.FASTAPI_ANALYSIS);
+		rateLimitService.consumeToken(request.userId(), ApiType.FASTAPI_CHAT);
 
 		String url = fastApiProperties.getBaseUrl() + "/ai/chat";
 		return webClient.post()
@@ -118,7 +118,7 @@ public class FastApiClient {
 	}
 
 	public Flux<String> streamInterviewEvaluation(FastApiInterviewEvaluationRequest request) {
-		rateLimitService.consumeToken(request.value().userId(), ApiType.FASTAPI_ANALYSIS);
+		rateLimitService.consumeToken(request.value().userId(), ApiType.FASTAPI_EVALUATION);
 
 		String url = fastApiProperties.getBaseUrl() + "/ai/evaluation/analyze";
 

--- a/src/main/java/com/ktb3/devths/global/ratelimit/config/properties/RateLimitProperties.java
+++ b/src/main/java/com/ktb3/devths/global/ratelimit/config/properties/RateLimitProperties.java
@@ -17,6 +17,8 @@ public class RateLimitProperties {
 	private GoogleCalendarLimit googleCalendar = new GoogleCalendarLimit();
 	private GoogleTasksLimit googleTasks = new GoogleTasksLimit();
 	private FastApiLimit fastapi = new FastApiLimit();
+	private FastApiChatLimit fastapiChat = new FastApiChatLimit();
+	private FastApiEvaluationLimit fastapiEvaluation = new FastApiEvaluationLimit();
 	private GoogleOAuthLimit googleOauth = new GoogleOAuthLimit();
 	private AuthTokenLimit authToken = new AuthTokenLimit();
 	private FilePresignedLimit filePresigned = new FilePresignedLimit();
@@ -48,6 +50,20 @@ public class RateLimitProperties {
 	@Setter
 	public static class FastApiLimit {
 		private int bucketCapacity = 10;
+		private boolean enabled = true;
+	}
+
+	@Getter
+	@Setter
+	public static class FastApiChatLimit {
+		private int bucketCapacity = 500;
+		private boolean enabled = true;
+	}
+
+	@Getter
+	@Setter
+	public static class FastApiEvaluationLimit {
+		private int bucketCapacity = 30;
 		private boolean enabled = true;
 	}
 

--- a/src/main/java/com/ktb3/devths/global/ratelimit/domain/constant/ApiType.java
+++ b/src/main/java/com/ktb3/devths/global/ratelimit/domain/constant/ApiType.java
@@ -9,6 +9,8 @@ public enum ApiType {
 	GOOGLE_CALENDAR("google.calendar", "Google Calendar API (쓰기 작업)"),
 	GOOGLE_TASKS("google.tasks", "Google Tasks API (쓰기 작업)"),
 	FASTAPI_ANALYSIS("fastapi.analysis", "FastAPI 분석 요청"),
+	FASTAPI_CHAT("fastapi.chat", "FastAPI 챗봇 메시지"),
+	FASTAPI_EVALUATION("fastapi.evaluation", "FastAPI 면접 평가"),
 	GOOGLE_OAUTH("google.oauth", "Google OAuth2 로그인"),
 	AUTH_TOKEN("auth.token", "인증/토큰 처리"),
 	FILE_PRESIGNED("file.presigned", "파일 Presigned URL 발급"),

--- a/src/main/java/com/ktb3/devths/global/ratelimit/service/InMemoryRateLimitService.java
+++ b/src/main/java/com/ktb3/devths/global/ratelimit/service/InMemoryRateLimitService.java
@@ -90,6 +90,8 @@ public class InMemoryRateLimitService implements RateLimitService {
 			case GOOGLE_CALENDAR -> properties.getGoogleCalendar().getBucketCapacity();
 			case GOOGLE_TASKS -> properties.getGoogleTasks().getBucketCapacity();
 			case FASTAPI_ANALYSIS -> properties.getFastapi().getBucketCapacity();
+			case FASTAPI_CHAT -> properties.getFastapiChat().getBucketCapacity();
+			case FASTAPI_EVALUATION -> properties.getFastapiEvaluation().getBucketCapacity();
 			case GOOGLE_OAUTH -> properties.getGoogleOauth().getBucketCapacity();
 			case AUTH_TOKEN -> properties.getAuthToken().getBucketCapacity();
 			case FILE_PRESIGNED -> properties.getFilePresigned().getBucketCapacity();
@@ -104,6 +106,8 @@ public class InMemoryRateLimitService implements RateLimitService {
 			case GOOGLE_CALENDAR -> properties.getGoogleCalendar().isEnabled();
 			case GOOGLE_TASKS -> properties.getGoogleTasks().isEnabled();
 			case FASTAPI_ANALYSIS -> properties.getFastapi().isEnabled();
+			case FASTAPI_CHAT -> properties.getFastapiChat().isEnabled();
+			case FASTAPI_EVALUATION -> properties.getFastapiEvaluation().isEnabled();
 			case GOOGLE_OAUTH -> properties.getGoogleOauth().isEnabled();
 			case AUTH_TOKEN -> properties.getAuthToken().isEnabled();
 			case FILE_PRESIGNED -> properties.getFilePresigned().isEnabled();

--- a/src/main/java/com/ktb3/devths/global/ratelimit/service/RedisRateLimitService.java
+++ b/src/main/java/com/ktb3/devths/global/ratelimit/service/RedisRateLimitService.java
@@ -106,6 +106,8 @@ public class RedisRateLimitService implements RateLimitService {
 			case GOOGLE_CALENDAR -> properties.getGoogleCalendar().getBucketCapacity();
 			case GOOGLE_TASKS -> properties.getGoogleTasks().getBucketCapacity();
 			case FASTAPI_ANALYSIS -> properties.getFastapi().getBucketCapacity();
+			case FASTAPI_CHAT -> properties.getFastapiChat().getBucketCapacity();
+			case FASTAPI_EVALUATION -> properties.getFastapiEvaluation().getBucketCapacity();
 			case GOOGLE_OAUTH -> properties.getGoogleOauth().getBucketCapacity();
 			case AUTH_TOKEN -> properties.getAuthToken().getBucketCapacity();
 			case FILE_PRESIGNED -> properties.getFilePresigned().getBucketCapacity();
@@ -120,6 +122,8 @@ public class RedisRateLimitService implements RateLimitService {
 			case GOOGLE_CALENDAR -> properties.getGoogleCalendar().isEnabled();
 			case GOOGLE_TASKS -> properties.getGoogleTasks().isEnabled();
 			case FASTAPI_ANALYSIS -> properties.getFastapi().isEnabled();
+			case FASTAPI_CHAT -> properties.getFastapiChat().isEnabled();
+			case FASTAPI_EVALUATION -> properties.getFastapiEvaluation().isEnabled();
 			case GOOGLE_OAUTH -> properties.getGoogleOauth().isEnabled();
 			case AUTH_TOKEN -> properties.getAuthToken().isEnabled();
 			case FILE_PRESIGNED -> properties.getFilePresigned().isEnabled();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -105,6 +105,12 @@ ratelimit:
   fastapi:
     bucket-capacity: ${RATELIMIT_FASTAPI:10}
     enabled: true
+  fastapi-chat:
+    bucket-capacity: ${RATELIMIT_FASTAPI_CHAT:500}
+    enabled: true
+  fastapi-evaluation:
+    bucket-capacity: ${RATELIMIT_FASTAPI_EVALUATION:30}
+    enabled: true
   google-oauth:
     bucket-capacity: ${RATELIMIT_GOOGLE_OAUTH:50}
     enabled: true


### PR DESCRIPTION
## 📌 작업한 내용
- 이력서 분석 API의 Rate Limit 버킷 용량이 챗봇 응답 및 면접 평가 API와 공유되고 있던 문제를 해결하였습니다.
## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

#190 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인