### PR TITLE
fix: 1:1 채팅방 나간 후 재연결 시도 시 403 에러 해결 (#198)

### DIFF
--- a/src/main/java/com/ktb3/devths/chat/domain/entity/ChatRoom.java
+++ b/src/main/java/com/ktb3/devths/chat/domain/entity/ChatRoom.java
@@ -74,6 +74,10 @@ public class ChatRoom {
 		this.currentCount = Math.max(0, this.currentCount - 1);
 	}
 
+	public void incrementCount() {
+		this.currentCount++;
+	}
+
 	public void softDelete() {
 		this.isDeleted = true;
 		this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/ktb3/devths/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/ktb3/devths/chat/repository/ChatMessageRepository.java
@@ -1,9 +1,11 @@
 package com.ktb3.devths.chat.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -28,4 +30,27 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 		@Param("lastId") Long lastId,
 		Pageable pageable
 	);
+
+	@Query("SELECT m FROM ChatMessage m LEFT JOIN FETCH m.sender "
+		+ "WHERE m.chatRoom.id = :roomId AND m.createdAt >= :joinedAt "
+		+ "ORDER BY m.id DESC")
+	List<ChatMessage> findByChatRoomIdAndCreatedAtAfterOrderByIdDesc(
+		@Param("roomId") Long roomId,
+		@Param("joinedAt") LocalDateTime joinedAt,
+		Pageable pageable
+	);
+
+	@Query("SELECT m FROM ChatMessage m LEFT JOIN FETCH m.sender "
+		+ "WHERE m.chatRoom.id = :roomId AND m.id < :lastId AND m.createdAt >= :joinedAt "
+		+ "ORDER BY m.id DESC")
+	List<ChatMessage> findByChatRoomIdAndIdLessThanAndCreatedAtAfterOrderByIdDesc(
+		@Param("roomId") Long roomId,
+		@Param("lastId") Long lastId,
+		@Param("joinedAt") LocalDateTime joinedAt,
+		Pageable pageable
+	);
+
+	@Modifying
+	@Query("DELETE FROM ChatMessage m WHERE m.chatRoom.id = :roomId")
+	void deleteByChatRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/ktb3/devths/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ktb3/devths/chat/service/ChatMessageService.java
@@ -1,10 +1,12 @@
 package com.ktb3.devths.chat.service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ktb3.devths.chat.domain.constant.ChatMessageTypes;
+import com.ktb3.devths.chat.domain.constant.ChatRoomTypes;
 import com.ktb3.devths.chat.domain.entity.ChatMember;
 import com.ktb3.devths.chat.domain.entity.ChatMessage;
 import com.ktb3.devths.chat.domain.entity.ChatRoom;
@@ -22,6 +25,7 @@ import com.ktb3.devths.chat.dto.response.ChatMessageResponse;
 import com.ktb3.devths.chat.dto.response.ChatRoomNotification;
 import com.ktb3.devths.chat.repository.ChatMemberRepository;
 import com.ktb3.devths.chat.repository.ChatMessageRepository;
+import com.ktb3.devths.chat.repository.ChatPrivateRoomRepository;
 import com.ktb3.devths.chat.repository.ChatRoomRepository;
 import com.ktb3.devths.global.exception.CustomException;
 import com.ktb3.devths.global.response.ErrorCode;
@@ -45,6 +49,7 @@ public class ChatMessageService {
 	private static final int MAX_PAGE_SIZE = 100;
 
 	private final ChatRoomRepository chatRoomRepository;
+	private final ChatPrivateRoomRepository chatPrivateRoomRepository;
 	private final ChatMemberRepository chatMemberRepository;
 	private final ChatMessageRepository chatMessageRepository;
 	private final UserRepository userRepository;
@@ -63,9 +68,12 @@ public class ChatMessageService {
 		int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
 		Pageable pageable = PageRequest.of(0, pageSize + 1);
 
+		LocalDateTime joinedAt = member.getJoinedAt();
+
 		List<ChatMessage> messages = (lastId == null)
-			? chatMessageRepository.findByChatRoomIdOrderByIdDesc(roomId, pageable)
-			: chatMessageRepository.findByChatRoomIdAndIdLessThanOrderByIdDesc(roomId, lastId, pageable);
+			? chatMessageRepository.findByChatRoomIdAndCreatedAtAfterOrderByIdDesc(roomId, joinedAt, pageable)
+			: chatMessageRepository.findByChatRoomIdAndIdLessThanAndCreatedAtAfterOrderByIdDesc(roomId, lastId,
+			joinedAt, pageable);
 
 		boolean hasNext = messages.size() > pageSize;
 		List<ChatMessage> actualMessages = hasNext
@@ -104,6 +112,26 @@ public class ChatMessageService {
 
 		User sender = userRepository.findByIdAndIsWithdrawFalse(senderId)
 			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		if (chatRoom.getType() == ChatRoomTypes.PRIVATE) {
+			chatPrivateRoomRepository.findById(chatRoom.getId()).ifPresent(privateRoom -> {
+				User otherUser = privateRoom.getUser1().getId().equals(senderId)
+					? privateRoom.getUser2()
+					: privateRoom.getUser1();
+
+				Optional<ChatMember> otherMemberOpt = chatMemberRepository.findByChatRoomIdAndUserId(
+					chatRoom.getId(), otherUser.getId());
+				if (otherMemberOpt.isEmpty()) {
+					ChatMember rejoinMember = ChatMember.builder()
+						.chatRoom(chatRoom)
+						.user(otherUser)
+						.roomName(sender.getNickname())
+						.build();
+					chatMemberRepository.save(rejoinMember);
+					chatRoom.incrementCount();
+				}
+			});
+		}
 
 		ChatMessageTypes messageType;
 		try {

--- a/src/main/java/com/ktb3/devths/chat/service/ChatRoomService.java
+++ b/src/main/java/com/ktb3/devths/chat/service/ChatRoomService.java
@@ -22,6 +22,7 @@ import com.ktb3.devths.chat.dto.response.ChatRoomSummaryResponse;
 import com.ktb3.devths.chat.dto.response.ChatRoomUpdateResponse;
 import com.ktb3.devths.chat.dto.response.PrivateChatRoomCreateResponse;
 import com.ktb3.devths.chat.repository.ChatMemberRepository;
+import com.ktb3.devths.chat.repository.ChatMessageRepository;
 import com.ktb3.devths.chat.repository.ChatPrivateRoomRepository;
 import com.ktb3.devths.chat.repository.ChatRoomRepository;
 import com.ktb3.devths.global.exception.CustomException;
@@ -50,6 +51,7 @@ public class ChatRoomService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatPrivateRoomRepository chatPrivateRoomRepository;
 	private final ChatMemberRepository chatMemberRepository;
+	private final ChatMessageRepository chatMessageRepository;
 	private final S3AttachmentRepository s3AttachmentRepository;
 	private final UserRepository userRepository;
 
@@ -114,6 +116,19 @@ public class ChatRoomService {
 		Optional<ChatPrivateRoom> existingRoom = chatPrivateRoomRepository.findByDmKey(dmKey);
 		if (existingRoom.isPresent()) {
 			ChatRoom room = existingRoom.get().getRoom();
+
+			Optional<ChatMember> currentMemberOpt = chatMemberRepository.findByChatRoomIdAndUserId(
+				room.getId(), currentUserId);
+			if (currentMemberOpt.isEmpty()) {
+				ChatMember rejoinMember = ChatMember.builder()
+					.chatRoom(room)
+					.user(currentUser)
+					.roomName(targetUser.getNickname())
+					.build();
+				chatMemberRepository.save(rejoinMember);
+				room.incrementCount();
+			}
+
 			log.info("기존 1:1 채팅방 반환: roomId={}, dmKey={}", room.getId(), dmKey);
 			return new PrivateChatRoomCreateResponse(
 				room.getId(),
@@ -251,7 +266,9 @@ public class ChatRoomService {
 		chatRoom.decrementCount();
 
 		if (chatRoom.getCurrentCount() <= 0) {
-			chatRoom.softDelete();
+			chatMessageRepository.deleteByChatRoomId(roomId);
+			chatPrivateRoomRepository.deleteById(roomId);
+			chatRoomRepository.delete(chatRoom);
 		}
 	}
 


### PR DESCRIPTION
## 📌 작업한 내용
- 1:1 채팅방을 나간 후 재연결 시도 시 403 에러가 발생하던 문제를 해결하였습니다.
## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->
#198 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인