### PR TITLE
fix: 채팅방 내부 이미지 모아보기 썸네일 깨짐 현상 해결

### DIFF
--- a/src/main/java/com/ktb3/devths/chat/service/ChatRoomService.java
+++ b/src/main/java/com/ktb3/devths/chat/service/ChatRoomService.java
@@ -240,7 +240,7 @@ public class ChatRoomService {
 			.stream()
 			.map(attachment -> new ChatRoomDetailResponse.RecentImage(
 				attachment.getId(),
-				attachment.getS3Key(),
+				s3StorageService.getPublicUrl(attachment.getS3Key()),
 				attachment.getOriginalName(),
 				attachment.getCreatedAt()
 			))


### PR DESCRIPTION
## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 채팅방 내부에서 이미지 모아보기란의 썸네일이 깨지던 현상을 해결하였습니다.

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인