### PR TITLE
refactor: 면접 평가 시 메시지 쿼리를 interviewId 기반으로 변경 (#145)

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/chatbot/repository/AiChatMessageRepository.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/repository/AiChatMessageRepository.java
@@ -23,4 +23,7 @@ public interface AiChatMessageRepository extends JpaRepository<AiChatMessage, Lo
 		@Param("lastId") Long lastId,
 		Pageable pageable
 	);
+
+	@Query("SELECT m FROM AiChatMessage m WHERE m.interview.id = :interviewId ORDER BY m.id ASC")
+	List<AiChatMessage> findByInterviewIdOrderByIdAsc(@Param("interviewId") Long interviewId);
 }

--- a/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatInterviewService.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatInterviewService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -119,10 +118,7 @@ public class AiChatInterviewService {
 		}
 		AiChatRoom room = interview.getRoom();
 
-		List<AiChatMessage> messages = aiChatMessageRepository.findAll().stream()
-			.filter(msg -> msg.getInterview() != null && msg.getInterview().getId().equals(interviewId))
-			.sorted((a, b) -> a.getId().compareTo(b.getId()))
-			.collect(Collectors.toList());
+		List<AiChatMessage> messages = aiChatMessageRepository.findByInterviewIdOrderByIdAsc(interviewId);
 
 		if (messages.isEmpty()) {
 			throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);


### PR DESCRIPTION
## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 면접 평가 시 풀스캔 이후 필터링하던 기존 로직을 interviewId 기준 SELECT 쿼리로 변경하였습니다.

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->
#145 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인