### PR TITLE
refactor: 폴링 실패 로그를 최종 실패 시 1번만 남기게 변경

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/analysis/service/AsyncAnalysisProcessor.java
+++ b/src/main/java/com/ktb3/devths/ai/analysis/service/AsyncAnalysisProcessor.java
@@ -164,8 +164,6 @@ public class AsyncAnalysisProcessor {
 				throw new CustomException(ErrorCode.ANALYSIS_FAILED);
 			} catch (CustomException e) {
 				if (attempt < maxAttempts - 1) {
-					log.warn("FastAPI 작업 조회 실패 (재시도 예정): taskId={}, attempt={}/{}",
-						taskId, attempt + 1, maxAttempts);
 					try {
 						Thread.sleep(pollInterval);
 					} catch (InterruptedException ie) {
@@ -173,7 +171,6 @@ public class AsyncAnalysisProcessor {
 						throw new CustomException(ErrorCode.ANALYSIS_FAILED);
 					}
 				} else {
-					log.error("FastAPI 작업 조회 최종 실패: taskId={}", taskId);
 					throw e;
 				}
 			}
@@ -234,7 +231,6 @@ public class AsyncAnalysisProcessor {
 
 	protected void handleAnalysisFailure(Long taskId, String reason) {
 		asyncTaskService.markAsFailed(taskId, reason);
-		log.error("분석 실패 처리 완료: taskId={}, reason={}", taskId, LogSanitizer.sanitize(reason));
 	}
 
 	/**

--- a/src/main/java/com/ktb3/devths/ai/client/FastApiClient.java
+++ b/src/main/java/com/ktb3/devths/ai/client/FastApiClient.java
@@ -82,9 +82,7 @@ public class FastApiClient {
 			}
 
 			return response;
-
 		} catch (RestClientException e) {
-			log.error("FastAPI 작업 상태 조회 실패: taskId={}", taskId, e);
 			throw new CustomException(ErrorCode.FASTAPI_CONNECTION_FAILED);
 		}
 	}


### PR DESCRIPTION
## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 비동기 작업 polling 실패 시 로그를 최종 실패했을 때만 1번 남기게 수정하였습니다.

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인