### PR TITLE
feat: 트랜잭션 점유 시간 측정을 위한 AOP 구현 (#209)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.micrometer:micrometer-tracing-bridge-otel'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp'

--- a/src/main/java/com/ktb3/devths/global/aop/TransactionMonitoringAspect.java
+++ b/src/main/java/com/ktb3/devths/global/aop/TransactionMonitoringAspect.java
@@ -1,0 +1,58 @@
+package com.ktb3.devths.global.aop;
+
+import java.lang.reflect.Method;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+@Component
+@RequiredArgsConstructor
+public class TransactionMonitoringAspect {
+
+	private static final String OBSERVATION_NAME = "transaction";
+
+	private final ObservationRegistry observationRegistry;
+
+	@Around("@annotation(org.springframework.transaction.annotation.Transactional)")
+	public Object monitorTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		Method method = signature.getMethod();
+
+		Transactional txAnnotation = AnnotationUtils.findAnnotation(method, Transactional.class);
+
+		String className = joinPoint.getTarget().getClass().getSimpleName();
+		String methodName = method.getName();
+		boolean readOnly = txAnnotation != null && txAnnotation.readOnly();
+		String propagation = txAnnotation != null ? txAnnotation.propagation().name() : "REQUIRED";
+
+		Observation observation = Observation.createNotStarted(OBSERVATION_NAME, observationRegistry)
+			.lowCardinalityKeyValue("readOnly", String.valueOf(readOnly))
+			.lowCardinalityKeyValue("propagation", propagation)
+			.highCardinalityKeyValue("code.function", className + "." + methodName)
+			.start();
+
+		try {
+			return joinPoint.proceed();
+		} catch (Throwable e) {
+			observation.error(e);
+			throw e;
+		} finally {
+			observation.stop();
+		}
+	}
+}


### PR DESCRIPTION
## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- `@Transactional` 어노테이션이 붙은 메서드들의 실제 트랜잭션 점유 시간 계측을 위해 AOP를 구현하였습니다.
- 측정된 트랜잭션 점유 시간은 Grafana Tempo로 Export 됩니다.

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->
#209 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인