### PR TITLE
refactor: AiChatRoomController, AiChatRoomService에 Facade 패턴 적용 (#211)

### DIFF
--- a/src/main/java/com/ktb3/devths/ai/chatbot/controller/AiChatRoomController.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/controller/AiChatRoomController.java
@@ -14,8 +14,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.ktb3.devths.ai.chatbot.domain.entity.AiChatInterview;
-import com.ktb3.devths.ai.chatbot.domain.entity.AiChatRoom;
 import com.ktb3.devths.ai.chatbot.dto.request.AiChatMessageRequest;
 import com.ktb3.devths.ai.chatbot.dto.request.InterviewEndRequest;
 import com.ktb3.devths.ai.chatbot.dto.request.InterviewEvaluationRequest;
@@ -26,19 +24,15 @@ import com.ktb3.devths.ai.chatbot.dto.response.AiChatRoomListResponse;
 import com.ktb3.devths.ai.chatbot.dto.response.CurrentInterviewResponse;
 import com.ktb3.devths.ai.chatbot.dto.response.InterviewEndResponse;
 import com.ktb3.devths.ai.chatbot.dto.response.InterviewStartResponse;
-import com.ktb3.devths.ai.chatbot.repository.AiChatRoomRepository;
-import com.ktb3.devths.ai.chatbot.service.AiChatInterviewService;
-import com.ktb3.devths.ai.chatbot.service.AiChatMessageService;
 import com.ktb3.devths.ai.chatbot.service.AiChatRoomService;
-import com.ktb3.devths.global.exception.CustomException;
+import com.ktb3.devths.ai.chatbot.service.facade.AiChatStreamFacade;
+import com.ktb3.devths.ai.chatbot.service.facade.AiInterviewFacade;
 import com.ktb3.devths.global.response.ApiResponse;
-import com.ktb3.devths.global.response.ErrorCode;
 import com.ktb3.devths.global.security.UserPrincipal;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping("/api/ai-chatrooms")
@@ -46,9 +40,8 @@ import reactor.core.publisher.Mono;
 public class AiChatRoomController {
 
 	private final AiChatRoomService aiChatRoomService;
-	private final AiChatMessageService aiChatMessageService;
-	private final AiChatInterviewService aiChatInterviewService;
-	private final AiChatRoomRepository aiChatRoomRepository;
+	private final AiInterviewFacade aiInterviewFacade;
+	private final AiChatStreamFacade aiChatStreamFacade;
 
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201")
 	@PostMapping
@@ -112,32 +105,7 @@ public class AiChatRoomController {
 		@PathVariable Long roomId,
 		@Valid @RequestBody AiChatMessageRequest request
 	) {
-		Flux<String> chatStream = aiChatMessageService.streamChatResponse(
-			userPrincipal.getUserId(),
-			roomId,
-			request.content(),
-			request.model(),
-			request.interviewId()
-		);
-
-		return chatStream
-			.map(chunk -> {
-				if (chunk.startsWith("ERROR:")) {
-					String errorMsg = chunk.substring(6);
-					return ServerSentEvent.<String>builder()
-						.event("error")
-						.data("{\"message\": \"" + errorMsg + "\"}")
-						.build();
-				}
-
-				return ServerSentEvent.<String>builder()
-					.data(chunk)
-					.build();
-			})
-			.concatWith(Mono.just(ServerSentEvent.<String>builder()
-				.event("done")
-				.data("")
-				.build()));
+		return aiChatStreamFacade.sendMessageStream(userPrincipal.getUserId(), roomId, request);
 	}
 
 	@GetMapping("/{roomId}/interview/current")
@@ -145,22 +113,12 @@ public class AiChatRoomController {
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@PathVariable Long roomId
 	) {
-		AiChatRoom room = aiChatRoomRepository.findByIdAndIsDeletedFalse(roomId)
-			.orElseThrow(() -> new CustomException(ErrorCode.AI_CHATROOM_NOT_FOUND));
-
-		if (!room.getUser().getId().equals(userPrincipal.getUserId())) {
-			throw new CustomException(ErrorCode.AI_CHATROOM_ACCESS_DENIED);
-		}
-
-		var currentInterview = aiChatInterviewService.getCurrentInterview(roomId);
-
-		if (currentInterview.isEmpty()) {
+		CurrentInterviewResponse response = aiInterviewFacade.getCurrentInterview(userPrincipal.getUserId(), roomId);
+		if (response == null) {
 			return ResponseEntity.ok(
 				ApiResponse.success("진행 중인 면접이 없습니다.", null)
 			);
 		}
-
-		CurrentInterviewResponse response = CurrentInterviewResponse.from(currentInterview.get());
 		return ResponseEntity.ok(
 			ApiResponse.success("진행 중인 면접 정보를 조회했습니다.", response)
 		);
@@ -173,31 +131,14 @@ public class AiChatRoomController {
 		@PathVariable Long roomId,
 		@Valid @RequestBody InterviewStartRequest request
 	) {
-		AiChatRoom room = aiChatRoomRepository.findByIdAndIsDeletedFalse(roomId)
-			.orElseThrow(() -> new CustomException(ErrorCode.AI_CHATROOM_NOT_FOUND));
-
-		if (!room.getUser().getId().equals(userPrincipal.getUserId())) {
-			throw new CustomException(ErrorCode.AI_CHATROOM_ACCESS_DENIED);
-		}
-
-		AiChatInterview interview = aiChatInterviewService.startInterview(room, request.interviewType());
-
-		// 재진입 여부 확인 (질문 수가 0보다 크면 재진입)
-		boolean isResumed = interview.getCurrentQuestionCount() > 0;
-
-		InterviewStartResponse response = new InterviewStartResponse(
-			interview.getId(),
-			interview.getInterviewType().name(),
-			interview.getCurrentQuestionCount(),
-			isResumed
+		AiInterviewFacade.InterviewStartFacadeResult result = aiInterviewFacade.startInterview(
+			userPrincipal.getUserId(),
+			roomId,
+			request
 		);
 
-		String message = isResumed
-			? "기존 면접을 계속 진행합니다."
-			: "면접이 시작되었습니다.";
-
 		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(ApiResponse.success(message, response));
+			.body(ApiResponse.success(result.message(), result.response()));
 	}
 
 	@PostMapping("/{roomId}/interview/end")
@@ -206,15 +147,7 @@ public class AiChatRoomController {
 		@PathVariable Long roomId,
 		@Valid @RequestBody InterviewEndRequest request
 	) {
-		AiChatRoom room = aiChatRoomRepository.findByIdAndIsDeletedFalse(roomId)
-			.orElseThrow(() -> new CustomException(ErrorCode.AI_CHATROOM_NOT_FOUND));
-
-		if (!room.getUser().getId().equals(userPrincipal.getUserId())) {
-			throw new CustomException(ErrorCode.AI_CHATROOM_ACCESS_DENIED);
-		}
-
-		AiChatInterview interview = aiChatInterviewService.endInterview(roomId, request.interviewId());
-		InterviewEndResponse response = new InterviewEndResponse(interview.getId(), interview.getStatus().name());
+		InterviewEndResponse response = aiInterviewFacade.endInterview(userPrincipal.getUserId(), roomId, request);
 
 		return ResponseEntity.ok(
 			ApiResponse.success("면접이 종료되었습니다.", response)
@@ -227,33 +160,6 @@ public class AiChatRoomController {
 		@PathVariable Long roomId,
 		@Valid @RequestBody InterviewEvaluationRequest request
 	) {
-		AiChatRoom room = aiChatRoomRepository.findByIdAndIsDeletedFalse(roomId)
-			.orElseThrow(() -> new CustomException(ErrorCode.AI_CHATROOM_NOT_FOUND));
-
-		if (!room.getUser().getId().equals(userPrincipal.getUserId())) {
-			throw new CustomException(ErrorCode.AI_CHATROOM_ACCESS_DENIED);
-		}
-
-		boolean retry = request.retry() != null && request.retry();
-		Flux<String> evaluationStream = aiChatInterviewService.evaluateInterview(request.interviewId(), retry);
-
-		return evaluationStream
-			.map(chunk -> {
-				if (chunk.startsWith("ERROR:")) {
-					String errorMsg = chunk.substring(6);
-					return ServerSentEvent.<String>builder()
-						.event("error")
-						.data("{\"message\": \"" + errorMsg + "\"}")
-						.build();
-				}
-
-				return ServerSentEvent.<String>builder()
-					.data(chunk)
-					.build();
-			})
-			.concatWith(Mono.just(ServerSentEvent.<String>builder()
-				.event("done")
-				.data("")
-				.build()));
+		return aiChatStreamFacade.evaluateInterviewStream(userPrincipal.getUserId(), roomId, request);
 	}
 }

--- a/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatRoomService.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/service/AiChatRoomService.java
@@ -57,24 +57,14 @@ public class AiChatRoomService {
 
 	@Transactional
 	public void deleteChatRoom(Long userId, Long roomId) {
-		AiChatRoom chatRoom = aiChatRoomRepository.findByIdAndIsDeletedFalse(roomId)
-			.orElseThrow(() -> new CustomException(ErrorCode.AI_CHATROOM_NOT_FOUND));
-
-		if (!chatRoom.getUser().getId().equals(userId)) {
-			throw new CustomException(ErrorCode.AI_CHATROOM_ACCESS_DENIED);
-		}
+		AiChatRoom chatRoom = getOwnedRoomOrThrow(userId, roomId);
 
 		chatRoom.delete();
 	}
 
 	@Transactional
 	public AiChatMessageListResponse getChatMessages(Long userId, Long roomId, Integer size, Long lastId) {
-		AiChatRoom chatRoom = aiChatRoomRepository.findByIdAndIsDeletedFalse(roomId)
-			.orElseThrow(() -> new CustomException(ErrorCode.AI_CHATROOM_NOT_FOUND));
-
-		if (!chatRoom.getUser().getId().equals(userId)) {
-			throw new CustomException(ErrorCode.AI_CHATROOM_ACCESS_DENIED);
-		}
+		AiChatRoom chatRoom = getOwnedRoomOrThrow(userId, roomId);
 
 		int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
 		Pageable pageable = PageRequest.of(0, pageSize + 1);
@@ -104,5 +94,17 @@ public class AiChatRoomService {
 			: aiChatRoomRepository.findByUserIdAndNotDeletedAfterCursor(userId, lastId, pageable);
 
 		return AiChatRoomListResponse.of(chatRooms, pageSize);
+	}
+
+	@Transactional(readOnly = true)
+	public AiChatRoom getOwnedRoomOrThrow(Long userId, Long roomId) {
+		AiChatRoom room = aiChatRoomRepository.findByIdAndIsDeletedFalse(roomId)
+			.orElseThrow(() -> new CustomException(ErrorCode.AI_CHATROOM_NOT_FOUND));
+
+		if (!room.getUser().getId().equals(userId)) {
+			throw new CustomException(ErrorCode.AI_CHATROOM_ACCESS_DENIED);
+		}
+
+		return room;
 	}
 }

--- a/src/main/java/com/ktb3/devths/ai/chatbot/service/facade/AiChatStreamFacade.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/service/facade/AiChatStreamFacade.java
@@ -1,0 +1,78 @@
+package com.ktb3.devths.ai.chatbot.service.facade;
+
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Service;
+
+import com.ktb3.devths.ai.chatbot.dto.request.AiChatMessageRequest;
+import com.ktb3.devths.ai.chatbot.dto.request.InterviewEvaluationRequest;
+import com.ktb3.devths.ai.chatbot.service.AiChatInterviewService;
+import com.ktb3.devths.ai.chatbot.service.AiChatMessageService;
+import com.ktb3.devths.ai.chatbot.service.AiChatRoomService;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class AiChatStreamFacade {
+
+	private static final String ERROR_PREFIX = "ERROR:";
+
+	private final AiChatRoomService aiChatRoomService;
+	private final AiChatMessageService aiChatMessageService;
+	private final AiChatInterviewService aiChatInterviewService;
+
+	public Flux<ServerSentEvent<String>> sendMessageStream(Long userId, Long roomId, AiChatMessageRequest request) {
+		aiChatRoomService.getOwnedRoomOrThrow(userId, roomId);
+
+		Flux<String> chatStream = aiChatMessageService.streamChatResponse(
+			userId,
+			roomId,
+			request.content(),
+			request.model(),
+			request.interviewId()
+		);
+		return toSseStream(chatStream);
+	}
+
+	public Flux<ServerSentEvent<String>> evaluateInterviewStream(
+		Long userId,
+		Long roomId,
+		InterviewEvaluationRequest request
+	) {
+		aiChatRoomService.getOwnedRoomOrThrow(userId, roomId);
+
+		boolean retry = request.retry() != null && request.retry();
+		Flux<String> evaluationStream = aiChatInterviewService.evaluateInterview(request.interviewId(), retry);
+		return toSseStream(evaluationStream);
+	}
+
+	private Flux<ServerSentEvent<String>> toSseStream(Flux<String> source) {
+		return source
+			.map(chunk -> chunk.startsWith(ERROR_PREFIX)
+				? buildErrorEvent(chunk.substring(ERROR_PREFIX.length()))
+				: buildDataEvent(chunk))
+			.concatWith(Mono.just(buildDoneEvent()));
+	}
+
+	private ServerSentEvent<String> buildErrorEvent(String errorMsg) {
+		return ServerSentEvent.<String>builder()
+			.event("error")
+			.data("{\"message\": \"" + errorMsg + "\"}")
+			.build();
+	}
+
+	private ServerSentEvent<String> buildDataEvent(String chunk) {
+		return ServerSentEvent.<String>builder()
+			.data(chunk)
+			.build();
+	}
+
+	private ServerSentEvent<String> buildDoneEvent() {
+		return ServerSentEvent.<String>builder()
+			.event("done")
+			.data("")
+			.build();
+	}
+}

--- a/src/main/java/com/ktb3/devths/ai/chatbot/service/facade/AiInterviewFacade.java
+++ b/src/main/java/com/ktb3/devths/ai/chatbot/service/facade/AiInterviewFacade.java
@@ -1,0 +1,56 @@
+package com.ktb3.devths.ai.chatbot.service.facade;
+
+import org.springframework.stereotype.Service;
+
+import com.ktb3.devths.ai.chatbot.domain.entity.AiChatInterview;
+import com.ktb3.devths.ai.chatbot.domain.entity.AiChatRoom;
+import com.ktb3.devths.ai.chatbot.dto.request.InterviewEndRequest;
+import com.ktb3.devths.ai.chatbot.dto.request.InterviewStartRequest;
+import com.ktb3.devths.ai.chatbot.dto.response.CurrentInterviewResponse;
+import com.ktb3.devths.ai.chatbot.dto.response.InterviewEndResponse;
+import com.ktb3.devths.ai.chatbot.dto.response.InterviewStartResponse;
+import com.ktb3.devths.ai.chatbot.service.AiChatInterviewService;
+import com.ktb3.devths.ai.chatbot.service.AiChatRoomService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AiInterviewFacade {
+
+	private final AiChatRoomService aiChatRoomService;
+	private final AiChatInterviewService aiChatInterviewService;
+
+	public CurrentInterviewResponse getCurrentInterview(Long userId, Long roomId) {
+		aiChatRoomService.getOwnedRoomOrThrow(userId, roomId);
+
+		return aiChatInterviewService.getCurrentInterview(roomId)
+			.map(CurrentInterviewResponse::from)
+			.orElse(null);
+	}
+
+	public InterviewStartFacadeResult startInterview(Long userId, Long roomId, InterviewStartRequest request) {
+		AiChatRoom room = aiChatRoomService.getOwnedRoomOrThrow(userId, roomId);
+		AiChatInterview interview = aiChatInterviewService.startInterview(room, request.interviewType());
+
+		boolean isResumed = interview.getCurrentQuestionCount() > 0;
+		InterviewStartResponse response = new InterviewStartResponse(
+			interview.getId(),
+			interview.getInterviewType().name(),
+			interview.getCurrentQuestionCount(),
+			isResumed
+		);
+
+		String message = isResumed ? "기존 면접을 계속 진행합니다." : "면접이 시작되었습니다.";
+		return new InterviewStartFacadeResult(message, response);
+	}
+
+	public InterviewEndResponse endInterview(Long userId, Long roomId, InterviewEndRequest request) {
+		aiChatRoomService.getOwnedRoomOrThrow(userId, roomId);
+		AiChatInterview interview = aiChatInterviewService.endInterview(roomId, request.interviewId());
+		return new InterviewEndResponse(interview.getId(), interview.getStatus().name());
+	}
+
+	public record InterviewStartFacadeResult(String message, InterviewStartResponse response) {
+	}
+}


### PR DESCRIPTION
## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- `AiChatRoomController`와 `AiChatRoomService`에 Facade 패턴을 적용하여 코드 복잡도를 개선했습니다.

## 🔍 참고 사항

### 왜 퍼사드 패턴을 선택했는가

1. 현재 문제의 본질이 복잡한 조합(orchestration)이기 때문
    - `AiChatRoomController` 문제는 도메인 규칙 그 자체보다, 여러 서비스/리포지토리/응답 포맷을 조합하는 책임이 컨트롤러에 있는 점
    - 퍼사드는 바로 이 조합 책임을 흡수하는 데 최적화된 패턴
2. 기존 서비스 설계를 크게 깨지 않고 개선 가능
    - `AiChatRoomService`, `AiChatMessageService`, `AiChatInterviewService`를 유지하면서 퍼사드가 유스케이스 단위로 묶어 호출하면 됨
    - 즉, 리스크가 낮고 단계적 적용이 쉬움
3. 컨트롤러 중복 제거 효과가 즉시 큼
    - 반복되는 room ownership 검증과 SSE error/done 이벤트 래핑 제거

### 퍼사드 적용 후 효과

1. `AiChatRoomController` 의존성 감소
    - 현재 4개 의존성 → 퍼사드 1~2개로 축소
2. 컨트롤러 코드 길이/중복 감소
    - 권한 검증 블록 반복 제거
    - SSE 이벤트 변환 중복 제거
3. 변경 용이성 증가
    - 권한정책 변경, 인터뷰 흐름 변경, SSE 포맷 변경 시 퍼사드 수정 중심
4. 테스트/수동 검증 관점도 좋아짐
    - 유스케이스 단위 진입점이 생겨서 검증 포인트가 명확해짐

### 적용 과정에서 주의했던 점

1. 퍼사드가 모든 로직을 먹지 않도록 유의
    - 도메인 규칙은 기존 서비스/엔티티에 유지
    - 퍼사드는 순서/조합/입출력 조립 중심
2. 유스케이스 기준으로 퍼사드를 분리
    - 예: `AiInterviewFacade`, `AiChatStreamFacade`
    - 하나의 거대한 `AiChatbotFacade`는 다시 비대해질 수 있음
3. 퍼사드에서 Repository 직접 접근 최소화
    - 가능하면 기존 서비스를 통해 접근
    - 단, 권한검증용 조회 최적화(fetch join 등)는 예외적으로 허용 가능

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->
#211 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인