### PR TITLE
feat: PostDetail 관련 캐시 도입 (#216)

### DIFF
--- a/src/main/java/com/ktb3/devths/board/service/PostDetailCacheService.java
+++ b/src/main/java/com/ktb3/devths/board/service/PostDetailCacheService.java
@@ -1,0 +1,116 @@
+package com.ktb3.devths.board.service;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.ktb3.devths.board.dto.response.PostDetailResponse;
+import com.ktb3.devths.global.config.CacheConfig;
+import com.ktb3.devths.global.config.properties.AppCacheProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostDetailCacheService {
+
+	private static final String KEY_PREFIX = "v1:post:";
+	private static final String VIEWER_SEGMENT = ":viewer:";
+	private static final String INDEX_PREFIX = "v1:cache-index:post:";
+	private static final Duration INDEX_TTL_BUFFER = Duration.ofSeconds(30);
+
+	private final CacheManager cacheManager;
+	private final StringRedisTemplate stringRedisTemplate;
+	private final AppCacheProperties appCacheProperties;
+
+	public Optional<PostDetailResponse> get(Long postId, Long userId) {
+		if (!isEnabled()) {
+			return Optional.empty();
+		}
+
+		try {
+			Cache.ValueWrapper wrapper = getCache().get(buildCacheKey(postId, userId));
+			if (wrapper == null) {
+				return Optional.empty();
+			}
+
+			Object value = wrapper.get();
+			if (value instanceof PostDetailResponse response) {
+				return Optional.of(response);
+			}
+
+			return Optional.empty();
+		} catch (Exception e) {
+			log.warn("PostDetail 캐시 조회 실패: postId={}, userId={}", postId, userId, e);
+			return Optional.empty();
+		}
+	}
+
+	public void put(Long postId, Long userId, PostDetailResponse response) {
+		if (!isEnabled()) {
+			return;
+		}
+
+		String cacheKey = buildCacheKey(postId, userId);
+		try {
+			getCache().put(cacheKey, response);
+			registerIndex(postId, cacheKey);
+		} catch (Exception e) {
+			log.warn("PostDetail 캐시 저장 실패: postId={}, userId={}", postId, userId, e);
+		}
+	}
+
+	public void evictByPostId(Long postId) {
+		if (!isEnabled()) {
+			return;
+		}
+
+		String indexKey = buildIndexKey(postId);
+		try {
+			Set<String> cacheKeys = stringRedisTemplate.opsForSet().members(indexKey);
+			if (cacheKeys != null) {
+				Cache cache = getCache();
+				for (String cacheKey : cacheKeys) {
+					cache.evict(cacheKey);
+				}
+			}
+			stringRedisTemplate.delete(indexKey);
+		} catch (Exception e) {
+			log.warn("PostDetail 캐시 무효화 실패: postId={}", postId, e);
+		}
+	}
+
+	private void registerIndex(Long postId, String cacheKey) {
+		String indexKey = buildIndexKey(postId);
+		stringRedisTemplate.opsForSet().add(indexKey, cacheKey);
+		Duration ttl = appCacheProperties.getPostDetail().getTtl().plus(INDEX_TTL_BUFFER);
+		stringRedisTemplate.expire(indexKey, ttl);
+	}
+
+	private boolean isEnabled() {
+		return appCacheProperties.isEnabled() && appCacheProperties.getPostDetail().isEnabled();
+	}
+
+	private Cache getCache() {
+		Cache cache = cacheManager.getCache(CacheConfig.POST_DETAIL_CACHE);
+		if (cache == null) {
+			throw new IllegalStateException("postDetail cache is not configured");
+		}
+		return cache;
+	}
+
+	private String buildCacheKey(Long postId, Long userId) {
+		return KEY_PREFIX + postId + VIEWER_SEGMENT + userId;
+	}
+
+	private String buildIndexKey(Long postId) {
+		return INDEX_PREFIX + postId;
+	}
+}

--- a/src/main/java/com/ktb3/devths/board/service/PostService.java
+++ b/src/main/java/com/ktb3/devths/board/service/PostService.java
@@ -3,6 +3,7 @@ package com.ktb3.devths.board.service;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
@@ -55,6 +56,7 @@ public class PostService {
 	private final UserInterestRepository userInterestRepository;
 	private final S3AttachmentRepository s3AttachmentRepository;
 	private final S3StorageService s3StorageService;
+	private final PostDetailCacheService postDetailCacheService;
 
 	@Transactional
 	public PostCreateResponse createPost(Long userId, PostCreateRequest request) {
@@ -90,6 +92,7 @@ public class PostService {
 
 		unlinkExistingAttachments(postId);
 		linkAttachments(postId, userId, request.fileIds());
+		postDetailCacheService.evictByPostId(postId);
 
 		return PostUpdateResponse.from(post);
 	}
@@ -133,6 +136,11 @@ public class PostService {
 
 	@Transactional(readOnly = true)
 	public PostDetailResponse getPostDetail(Long userId, Long postId) {
+		Optional<PostDetailResponse> cached = postDetailCacheService.get(postId, userId);
+		if (cached.isPresent()) {
+			return cached.get();
+		}
+
 		Post post = postRepository.findByIdAndIsDeletedFalseWithUser(postId)
 			.orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
@@ -162,7 +170,11 @@ public class PostService {
 
 		boolean isLiked = likeRepository.existsByPostIdAndUserId(postId, userId);
 
-		return PostDetailResponse.of(post, attachments, postTags, authorInfo, isLiked, s3StorageService);
+		PostDetailResponse response = PostDetailResponse.of(post, attachments, postTags, authorInfo, isLiked,
+			s3StorageService);
+		postDetailCacheService.put(postId, userId, response);
+
+		return response;
 	}
 
 	@Transactional
@@ -175,6 +187,7 @@ public class PostService {
 		}
 
 		post.delete();
+		postDetailCacheService.evictByPostId(postId);
 	}
 
 	@Transactional
@@ -197,6 +210,7 @@ public class PostService {
 
 		likeRepository.save(like);
 		post.incrementLikeCount();
+		postDetailCacheService.evictByPostId(postId);
 
 		return PostLikeResponse.from(post);
 	}
@@ -215,6 +229,7 @@ public class PostService {
 
 		likeRepository.delete(like);
 		post.decrementLikeCount();
+		postDetailCacheService.evictByPostId(postId);
 	}
 
 	private List<Post> fetchPosts(String keyword, boolean hasKeyword, Long lastId, Pageable pageable) {

--- a/src/main/java/com/ktb3/devths/global/config/CacheConfig.java
+++ b/src/main/java/com/ktb3/devths/global/config/CacheConfig.java
@@ -1,0 +1,57 @@
+package com.ktb3.devths.global.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.support.NoOpCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ktb3.devths.global.config.properties.AppCacheProperties;
+
+@Configuration
+@EnableCaching
+@ConditionalOnClass(RedisCacheManager.class)
+public class CacheConfig {
+
+	public static final String POST_DETAIL_CACHE = "postDetail";
+
+	@Bean
+	public CacheManager cacheManager(
+		RedisConnectionFactory redisConnectionFactory,
+		ObjectMapper objectMapper,
+		AppCacheProperties appCacheProperties
+	) {
+		if (!appCacheProperties.isEnabled() || !appCacheProperties.getPostDetail().isEnabled()) {
+			return new NoOpCacheManager();
+		}
+
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper.copy());
+
+		RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+			.disableCachingNullValues()
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+			.entryTtl(Duration.ofMinutes(5));
+
+		Map<String, RedisCacheConfiguration> cacheConfigs = new HashMap<>();
+		cacheConfigs.put(
+			POST_DETAIL_CACHE,
+			defaultConfig.entryTtl(appCacheProperties.getPostDetail().getTtl())
+		);
+
+		return RedisCacheManager.builder(redisConnectionFactory)
+			.cacheDefaults(defaultConfig)
+			.withInitialCacheConfigurations(cacheConfigs)
+			.build();
+	}
+}

--- a/src/main/java/com/ktb3/devths/global/config/properties/AppCacheProperties.java
+++ b/src/main/java/com/ktb3/devths/global/config/properties/AppCacheProperties.java
@@ -1,0 +1,26 @@
+package com.ktb3.devths.global.config.properties;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.cache")
+public class AppCacheProperties {
+
+	private boolean enabled = false;
+	private PostDetail postDetail = new PostDetail();
+
+	@Getter
+	@Setter
+	public static class PostDetail {
+		private boolean enabled = false;
+		private Duration ttl = Duration.ofSeconds(60);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,6 +120,13 @@ chat:
     heartbeat-send-interval-ms: 10000
     heartbeat-receive-interval-ms: 10000
 
+app:
+  cache:
+    enabled: true
+    post-detail:
+      enabled: true
+      ttl: 60s
+
 ratelimit:
   backend: ${RATELIMIT_BACKEND:in-memory}
   redis:


### PR DESCRIPTION
## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 게시글 상세 보기(PostDetail) API에 Redis Cache를 적용하였습니다.
- 단건 상세 보기에서 발생하는 다수의 쿼리로 인한 네트워크 비용을 절감하여 사용자 경험을 개선합니다.
- Look-Aside 전략을 채택하여 Cache Hit/Miss에 상관 없이 API 응답 실패를 회피합니다.
 
## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->
#216 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인