### PR TITLE
fix: 스테이징 브랜치명 인식 실패 문제 수정 (#218)

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -42,7 +42,7 @@ case $DEVELOP in
     PARAM_PATH="/Dev/BE"
     SPRING_PROFILE="dev"
     ;;
-  staging)
+  release/*|staging)
     PARAM_PATH="/Stg/BE"
     SPRING_PROFILE="stg"
     ;;


### PR DESCRIPTION
## 📌 작업한 내용
- 스테이징 브랜치명을 인식하지 못해 발생하던 문제를 수정했습니다.
- GitHub Actions 워크플로우에서 브랜치 이름 파싱 로직을 강화하여 정확한 매칭을 수행하도록 변경했습니다.
- 관련 이슈 #218에서 지적된 스테이징 배포 시나리오를 테스트하며 브랜치 패턴(예: staging/ 또는 release/staging)을 명확히 처리했습니다.

## 🔍 참고 사항
- 브랜치명에 대소문자나 특수 패턴이 포함된 경우 추가 테스트를 권장합니다.
- 스테이징 환경 배포 후 Actions 로그를 확인하여 인식 여부를 검증해 주세요.

## 🖼️ 스크린샷
- 해당 PR은 Actions 설정 파일 변경 위주라 별도의 UI 변경 사항은 없습니다.

## 🔗 관련 이슈
- #218

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인