### PR TITLE
fix: release/v1.1.0-alpha 브랜치명 인식 실패 수정

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -42,7 +42,7 @@ case $DEVELOP in
     PARAM_PATH="/Dev/BE"
     SPRING_PROFILE="dev"
     ;;
-  staging)
+  release/*|staging)
     PARAM_PATH="/Stg/BE"
     SPRING_PROFILE="stg"
     ;;


### PR DESCRIPTION
## 📌 작업한 내용
- 스테이징 브랜치명을 인식하지 못해 발생하던 문제를 수정했습니다.
- GitHub Actions 워크플로우에서 브랜치 이름 파싱 로직을 강화하여 정확한 매칭을 수행하도록 변경했습니다.
- 관련 이슈 #218에서 지적된 스테이징 배포 시나리오를 테스트하며 브랜치 패턴(예: staging/ 또는 release/staging)을 명확히 처리했습니다.

## 🔍 참고 사항
- 현재는 fix->dev->release 구조이지만, 수정할 수 있습니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
#219 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인