### PR TITLE
fix: Loki 환경별 수정 진행 (#218)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     restart: unless-stopped
     environment:
       - LOKI_URL=${LOKI_URL}
+      - ENV=${ENV}
     volumes:
       - ./promtail-config.yml:/etc/promtail/config.yml:ro
       - ${LOG_FILE_DIRECTORY}:/app/log:ro

--- a/promtail-config.yml
+++ b/promtail-config.yml
@@ -5,6 +5,8 @@ server:
 # 1. 로그를 받을 Loki 주소
 clients:
   - url: ${LOKI_URL}
+    external_labels:
+      env: ${ENV}
 
 # 2. 로그를 어디까지 읽었는지 저장하는 파일
 positions:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -61,6 +61,10 @@ echo "> Spring Profile: $SPRING_PROFILE"
 
 echo "> Parameter Store 경로: $PARAM_PATH"
 
+# 환경 변수 설정 (Promtail 설정에 사용)
+export ENV="$SPRING_PROFILE"
+echo "> 환경(ENV): $ENV"
+
 # Parameter Store에서 파라미터 가져와서 임시 .env 파일 생성
 # --recursive: 하위 경로의 모든 파라미터 가져오기
 # --with-decryption: SecureString 타입 파라미터 복호화


### PR DESCRIPTION
## 📌 작업한 내용
- Loki 로그 설정을 개발용과 스테이징용으로 환경별 분리했습니다.
- Promtail 또는 로그 설정 파일에서 환경 레이블(예: env=dev/staging)을 추가하여 로그 태깅을 명확히 했습니다.
- 관련 이슈 #218에서 지적된 로그 구분 문제를 해결하여 Grafana Loki에서 환경별 필터링이 가능해졌습니다.

## 🔍 참고 사항
- 배포 후 Loki 대시보드에서 `{env="staging"}` 쿼리를 통해 스테이징 로그만 확인 가능합니다.
- 환경 변수통해 동적으로 env 레이블 적용

## 🖼️ 스크린샷
- Loki 탐색기에서 환경별 분리 로그 예시 스크린샷 첨부 예정 (변경 전/후 비교).

## 🔗 관련 이슈
- #218

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인