### PR TITLE
fix: Loki 환경별 이름 application.yml 수정 (#218)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: devths-be
+    name: devths-be-${SPRING_PROFILES_ACTIVE:local}
 
   datasource:
     url: ${DB_URL_V2}


### PR DESCRIPTION
## 📌 작업한 내용
- Loki 로그에서 환경별 이름(개발/스테이징)이 명확히 표시되도록 설정을 수정했습니다.
- 로그 레이블 또는 파싱 규칙을 조정하여 환경 구분명이 로그 라인에 직관적으로 노출되도록 했습니다.
- 관련 이슈 #218의 후속 조치로, 이전 환경 분리 설정을 보완하여 가독성을 높였습니다.

## 🔍 참고 사항
- 배포 후 Loki 탐색기에서 환경 이름이 로그 각 줄에 함께 표시되는지 확인 부탁드립니다.
- 필요시 로그 포맷 템플릿을 추가 조정하여 운영팀 편의성을 높일 수 있습니다.

## 🖼️ 스크린샷
<img width="1733" height="471" alt="image" src="https://github.com/user-attachments/assets/e3cb95f0-84dc-4bcc-a0c9-0fd9aa661c4f" />


## 🔗 관련 이슈
- #218

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인