### PR TITLE
fix: WebSocket 연결 끊김 문제 해결 (#200)

### DIFF
--- a/src/main/java/com/ktb3/devths/chat/config/StompChannelInterceptor.java
+++ b/src/main/java/com/ktb3/devths/chat/config/StompChannelInterceptor.java
@@ -42,7 +42,12 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
 		switch (accessor.getCommand()) {
 			case CONNECT -> handleConnect(accessor);
-			case SUBSCRIBE -> handleSubscribe(accessor);
+			case SUBSCRIBE -> {
+				boolean allowed = handleSubscribe(accessor);
+				if (!allowed) {
+					return null;
+				}
+			}
 			default -> {
 			}
 		}
@@ -65,9 +70,11 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 			Long userId = jwtTokenProvider.getUserIdFromToken(token);
 
 			Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
-			if (sessionAttributes != null) {
-				sessionAttributes.put("userId", userId);
+			if (sessionAttributes == null) {
+				log.warn("WebSocket CONNECT: sessionAttributes 없음");
+				throw new CustomException(ErrorCode.WEBSOCKET_AUTH_FAILED);
 			}
+			sessionAttributes.put("userId", userId);
 
 			log.info("WebSocket 인증 성공: userId={}", userId);
 		} catch (CustomException e) {
@@ -76,25 +83,26 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 		}
 	}
 
-	private void handleSubscribe(StompHeaderAccessor accessor) {
+	private boolean handleSubscribe(StompHeaderAccessor accessor) {
 		String destination = accessor.getDestination();
 
 		if (destination == null) {
-			return;
+			return true;
 		}
 
 		if (destination.startsWith(CHATROOM_TOPIC_PREFIX)) {
-			handleChatroomSubscribe(accessor, destination);
+			return handleChatroomSubscribe(accessor, destination);
 		} else if (destination.startsWith(USER_TOPIC_PREFIX) && destination.endsWith(USER_TOPIC_SUFFIX)) {
-			handleUserNotificationSubscribe(accessor, destination);
+			return handleUserNotificationSubscribe(accessor, destination);
 		}
+		return true;
 	}
 
-	private void handleChatroomSubscribe(StompHeaderAccessor accessor, String destination) {
+	private boolean handleChatroomSubscribe(StompHeaderAccessor accessor, String destination) {
 		Long userId = getUserIdFromSession(accessor);
 		if (userId == null) {
-			log.warn("WebSocket SUBSCRIBE: 세션에 userId 없음");
-			throw new CustomException(ErrorCode.WEBSOCKET_AUTH_FAILED);
+			log.warn("WebSocket SUBSCRIBE 거부: 세션에 userId 없음");
+			return false;
 		}
 
 		String roomIdStr = destination.replace(CHATROOM_TOPIC_PREFIX, "");
@@ -102,24 +110,24 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 		try {
 			roomId = Long.parseLong(roomIdStr);
 		} catch (NumberFormatException e) {
-			log.warn("WebSocket SUBSCRIBE: 잘못된 roomId={}", roomIdStr);
-			throw new CustomException(ErrorCode.INVALID_REQUEST);
+			log.warn("WebSocket SUBSCRIBE 거부: 잘못된 roomId={}", roomIdStr);
+			return false;
 		}
 
-		chatMemberRepository.findByChatRoomIdAndUserId(roomId, userId)
-			.orElseThrow(() -> {
-				log.warn("WebSocket SUBSCRIBE: 채팅방 멤버 아님 - roomId={}, userId={}", roomId, userId);
-				return new CustomException(ErrorCode.CHATROOM_ACCESS_DENIED);
-			});
+		if (chatMemberRepository.findByChatRoomIdAndUserId(roomId, userId).isEmpty()) {
+			log.warn("WebSocket SUBSCRIBE 거부: 채팅방 멤버 아님 - roomId={}, userId={}", roomId, userId);
+			return false;
+		}
 
 		log.info("WebSocket 구독 인증 성공: roomId={}, userId={}", roomId, userId);
+		return true;
 	}
 
-	private void handleUserNotificationSubscribe(StompHeaderAccessor accessor, String destination) {
+	private boolean handleUserNotificationSubscribe(StompHeaderAccessor accessor, String destination) {
 		Long sessionUserId = getUserIdFromSession(accessor);
 		if (sessionUserId == null) {
-			log.warn("WebSocket SUBSCRIBE: 세션에 userId 없음");
-			throw new CustomException(ErrorCode.WEBSOCKET_AUTH_FAILED);
+			log.warn("WebSocket SUBSCRIBE 거부: 세션에 userId 없음");
+			return false;
 		}
 
 		String pathUserId = destination.replace(USER_TOPIC_PREFIX, "").replace(USER_TOPIC_SUFFIX, "");
@@ -127,17 +135,18 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 		try {
 			targetUserId = Long.parseLong(pathUserId);
 		} catch (NumberFormatException e) {
-			log.warn("WebSocket SUBSCRIBE: 잘못된 userId={}", pathUserId);
-			throw new CustomException(ErrorCode.INVALID_REQUEST);
+			log.warn("WebSocket SUBSCRIBE 거부: 잘못된 userId={}", pathUserId);
+			return false;
 		}
 
 		if (!sessionUserId.equals(targetUserId)) {
-			log.warn("WebSocket SUBSCRIBE: 타인의 알림 채널 구독 시도 - sessionUserId={}, targetUserId={}",
+			log.warn("WebSocket SUBSCRIBE 거부: 타인의 알림 채널 구독 시도 - sessionUserId={}, targetUserId={}",
 				sessionUserId, targetUserId);
-			throw new CustomException(ErrorCode.ACCESS_DENIED);
+			return false;
 		}
 
 		log.info("WebSocket 알림 구독 성공: userId={}", sessionUserId);
+		return true;
 	}
 
 	private Long getUserIdFromSession(StompHeaderAccessor accessor) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,8 +117,8 @@ fastapi:
 
 chat:
   websocket:
-    heartbeat-send-interval-ms: 10000
-    heartbeat-receive-interval-ms: 10000
+    heartbeat-send-interval-ms: 25000
+    heartbeat-receive-interval-ms: 25000
 
 app:
   cache:


### PR DESCRIPTION
## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- WebSocket(STOMP) 연결이 간헐적으로 끊기는 문제를 해결하였습니다.
- SUBSCRIBE 실패 시 `null`을 `return`하여 세션은 유지하되 해당 구독만 드롭하게 변경하였습니다.
- `handleSubscribe()`, `handleChatroomSubscribe()`, `handleUserNotificationSubscribe()`: `void` → `boolean` 반환, `throw` 대신 `return` false하게 변경하였습니다.
- `handleConnect()`: `sessionAttributes == null` 시 즉시 `throw`하게 변경하였습니다.
- Heartbeat의 간격을 10초에서 25초로 증가시켰습니다.

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->
#200 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인