### PR TITLE
fix: 채팅 알림 구독 Pub/Sub 별도의 trace로 분리 (#229)

### DIFF
--- a/src/main/java/com/ktb3/devths/chat/service/RedisPublisher.java
+++ b/src/main/java/com/ktb3/devths/chat/service/RedisPublisher.java
@@ -72,38 +72,51 @@ public class RedisPublisher {
 	public void publishNotification(Long userId, ChatRoomNotification notification, String chatSessionId) {
 		String sanitizedUserId = LogSanitizer.sanitize(String.valueOf(userId));
 
-		Span publishSpan = tracer.spanBuilder()
-			.name("chat.notification.redis.publish")
-			.kind(Span.Kind.PRODUCER)
-			.tag("messaging.system", "redis")
-			.tag("messaging.destination", NOTIFY_PREFIX + userId)
-			.tag("chat.user.id", sanitizedUserId)
-			.tag("chat.room.id", String.valueOf(notification.roomId()))
-			.tag("chat.session.id", chatSessionId)
-			.start();
+		String originTraceId = resolveCurrentTraceId();
 
-		try (Tracer.SpanInScope spanInScope = tracer.withSpan(publishSpan)) {
-			String channel = NOTIFY_PREFIX + userId;
-			ChatRedisNotificationEnvelope envelope = new ChatRedisNotificationEnvelope(
-				new ChatRedisNotificationMeta(
-					NOTIFICATION_EVENT_TYPE,
-					userId,
-					notification.roomId(),
-					chatSessionId
-				),
-				buildTraceContext(publishSpan),
-				notification
-			);
-			String message = objectMapper.writeValueAsString(envelope);
-			redisTemplate.convertAndSend(channel, message);
+		try (Tracer.SpanInScope clearScope = tracer.withSpan(null)) {
+			Span publishSpan = tracer.spanBuilder()
+				.name("chat.notification.redis.publish")
+				.kind(Span.Kind.PRODUCER)
+				.tag("messaging.system", "redis")
+				.tag("messaging.destination", NOTIFY_PREFIX + userId)
+				.tag("chat.user.id", sanitizedUserId)
+				.tag("chat.room.id", String.valueOf(notification.roomId()))
+				.tag("chat.session.id", chatSessionId)
+				.tag("chat.origin.trace.id", originTraceId)
+				.start();
 
-			log.debug("Redis 알림 발행 성공: userId={}", sanitizedUserId);
-		} catch (Exception e) {
-			publishSpan.error(e);
-			log.error("Redis 알림 발행 실패: userId={}", sanitizedUserId, e);
-		} finally {
-			publishSpan.end();
+			try (Tracer.SpanInScope spanInScope = tracer.withSpan(publishSpan)) {
+				String channel = NOTIFY_PREFIX + userId;
+				ChatRedisNotificationEnvelope envelope = new ChatRedisNotificationEnvelope(
+					new ChatRedisNotificationMeta(
+						NOTIFICATION_EVENT_TYPE,
+						userId,
+						notification.roomId(),
+						chatSessionId
+					),
+					buildTraceContext(publishSpan),
+					notification
+				);
+				String message = objectMapper.writeValueAsString(envelope);
+				redisTemplate.convertAndSend(channel, message);
+
+				log.debug("Redis 알림 발행 성공: userId={}", sanitizedUserId);
+			} catch (Exception e) {
+				publishSpan.error(e);
+				log.error("Redis 알림 발행 실패: userId={}", sanitizedUserId, e);
+			} finally {
+				publishSpan.end();
+			}
 		}
+	}
+
+	private String resolveCurrentTraceId() {
+		Span currentSpan = tracer.currentSpan();
+		if (currentSpan != null && currentSpan.context() != null) {
+			return currentSpan.context().traceId();
+		}
+		return "unknown";
 	}
 
 	private ChatRedisTraceContext buildTraceContext(Span publishSpan) {


### PR DESCRIPTION
## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 채팅 알림 구독(Pub/Sub)을 별도의 trace로 분리하였습니다.
- 채팅 송수신과 새 메시지 알림이 Grafana Tempo에서 별개의 trace로 확인됩니다.

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->
#229 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인