### PR TITLE
fix: 캐시 Hit 시 DB 커넥션 획득하지 않게 수정

### DIFF
--- a/src/main/java/com/ktb3/devths/board/service/PostDetailQueryService.java
+++ b/src/main/java/com/ktb3/devths/board/service/PostDetailQueryService.java
@@ -1,0 +1,78 @@
+package com.ktb3.devths.board.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ktb3.devths.board.domain.entity.Post;
+import com.ktb3.devths.board.domain.entity.PostTag;
+import com.ktb3.devths.board.dto.response.PostDetailResponse;
+import com.ktb3.devths.board.dto.response.PostSummaryResponse;
+import com.ktb3.devths.board.repository.LikeRepository;
+import com.ktb3.devths.board.repository.PostRepository;
+import com.ktb3.devths.board.repository.PostTagRepository;
+import com.ktb3.devths.global.exception.CustomException;
+import com.ktb3.devths.global.response.ErrorCode;
+import com.ktb3.devths.global.storage.domain.constant.RefType;
+import com.ktb3.devths.global.storage.domain.entity.S3Attachment;
+import com.ktb3.devths.global.storage.repository.S3AttachmentRepository;
+import com.ktb3.devths.global.storage.service.S3StorageService;
+import com.ktb3.devths.user.domain.constant.Interests;
+import com.ktb3.devths.user.domain.entity.User;
+import com.ktb3.devths.user.repository.UserInterestRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostDetailQueryService {
+
+	private final PostRepository postRepository;
+	private final PostTagRepository postTagRepository;
+	private final LikeRepository likeRepository;
+	private final UserInterestRepository userInterestRepository;
+	private final S3AttachmentRepository s3AttachmentRepository;
+	private final S3StorageService s3StorageService;
+	private final PostDetailCacheService postDetailCacheService;
+
+	@Transactional(readOnly = true)
+	public PostDetailResponse loadAndCache(Long userId, Long postId) {
+		Post post = postRepository.findByIdAndIsDeletedFalseWithUser(postId)
+			.orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+		User author = post.getUser();
+		Long authorId = author.getId();
+
+		List<S3Attachment> attachments = s3AttachmentRepository
+			.findByRefTypeAndRefIdAndIsDeletedFalseOrderBySortOrderAsc(RefType.POST, postId);
+
+		List<PostTag> postTags = postTagRepository.findByPostIdIn(List.of(postId));
+
+		S3Attachment profileImage = s3AttachmentRepository
+			.findTopByRefTypeAndRefIdAndIsDeletedFalseOrderByCreatedAtDesc(RefType.USER, authorId)
+			.orElse(null);
+
+		String profileImageUrl = (profileImage != null)
+			? s3StorageService.getPublicUrl(profileImage.getS3Key())
+			: null;
+
+		List<String> interests = userInterestRepository.findInterestsByUserId(authorId).stream()
+			.map(Interests::getDisplayName)
+			.toList();
+
+		PostSummaryResponse.PostAuthorInfo authorInfo = new PostSummaryResponse.PostAuthorInfo(
+			authorId, author.getNickname(), profileImageUrl, interests
+		);
+
+		boolean isLiked = likeRepository.existsByPostIdAndUserId(postId, userId);
+
+		PostDetailResponse response = PostDetailResponse.of(post, attachments, postTags, authorInfo, isLiked,
+			s3StorageService);
+		postDetailCacheService.put(postId, userId, response);
+
+		return response;
+	}
+}

--- a/src/main/java/com/ktb3/devths/board/service/PostService.java
+++ b/src/main/java/com/ktb3/devths/board/service/PostService.java
@@ -21,7 +21,6 @@ import com.ktb3.devths.board.dto.response.PostCreateResponse;
 import com.ktb3.devths.board.dto.response.PostDetailResponse;
 import com.ktb3.devths.board.dto.response.PostLikeResponse;
 import com.ktb3.devths.board.dto.response.PostListResponse;
-import com.ktb3.devths.board.dto.response.PostSummaryResponse;
 import com.ktb3.devths.board.dto.response.PostUpdateResponse;
 import com.ktb3.devths.board.repository.LikeRepository;
 import com.ktb3.devths.board.repository.PostRepository;
@@ -32,7 +31,6 @@ import com.ktb3.devths.global.storage.domain.constant.RefType;
 import com.ktb3.devths.global.storage.domain.entity.S3Attachment;
 import com.ktb3.devths.global.storage.repository.S3AttachmentRepository;
 import com.ktb3.devths.global.storage.service.S3StorageService;
-import com.ktb3.devths.user.domain.constant.Interests;
 import com.ktb3.devths.user.domain.entity.User;
 import com.ktb3.devths.user.domain.entity.UserInterest;
 import com.ktb3.devths.user.repository.UserInterestRepository;
@@ -57,6 +55,7 @@ public class PostService {
 	private final S3AttachmentRepository s3AttachmentRepository;
 	private final S3StorageService s3StorageService;
 	private final PostDetailCacheService postDetailCacheService;
+	private final PostDetailQueryService postDetailQueryService;
 
 	@Transactional
 	public PostCreateResponse createPost(Long userId, PostCreateRequest request) {
@@ -134,47 +133,9 @@ public class PostService {
 		return PostListResponse.of(posts, pageSize, tagMap, profileImageMap, interestMap, s3StorageService);
 	}
 
-	@Transactional(readOnly = true)
 	public PostDetailResponse getPostDetail(Long userId, Long postId) {
 		Optional<PostDetailResponse> cached = postDetailCacheService.get(postId, userId);
-		if (cached.isPresent()) {
-			return cached.get();
-		}
-
-		Post post = postRepository.findByIdAndIsDeletedFalseWithUser(postId)
-			.orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-
-		User author = post.getUser();
-		Long authorId = author.getId();
-
-		List<S3Attachment> attachments = s3AttachmentRepository
-			.findByRefTypeAndRefIdAndIsDeletedFalseOrderBySortOrderAsc(RefType.POST, postId);
-
-		List<PostTag> postTags = postTagRepository.findByPostIdIn(List.of(postId));
-
-		S3Attachment profileImage = s3AttachmentRepository
-			.findTopByRefTypeAndRefIdAndIsDeletedFalseOrderByCreatedAtDesc(RefType.USER, authorId)
-			.orElse(null);
-
-		String profileImageUrl = (profileImage != null)
-			? s3StorageService.getPublicUrl(profileImage.getS3Key())
-			: null;
-
-		List<String> interests = userInterestRepository.findInterestsByUserId(authorId).stream()
-			.map(Interests::getDisplayName)
-			.toList();
-
-		PostSummaryResponse.PostAuthorInfo authorInfo = new PostSummaryResponse.PostAuthorInfo(
-			authorId, author.getNickname(), profileImageUrl, interests
-		);
-
-		boolean isLiked = likeRepository.existsByPostIdAndUserId(postId, userId);
-
-		PostDetailResponse response = PostDetailResponse.of(post, attachments, postTags, authorInfo, isLiked,
-			s3StorageService);
-		postDetailCacheService.put(postId, userId, response);
-
-		return response;
+		return cached.orElseGet(() -> postDetailQueryService.loadAndCache(userId, postId));
 	}
 
 	@Transactional


### PR DESCRIPTION
## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 캐시 Miss 발생 시에만 DB 커넥션을 획득하게 끔 트랜잭션 경계를 분리하였습니다.

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->
#216 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인